### PR TITLE
feat: add webpack param to TnsAssert.created()

### DIFF
--- a/products/nativescript/tns_assert.py
+++ b/products/nativescript/tns_assert.py
@@ -12,7 +12,7 @@ from products.nativescript.tns_helpers import TnsHelpers
 class TnsAssert(object):
 
     @staticmethod
-    def created(app_name, output=None, app_data=None, path=Settings.TEST_RUN_HOME, theme=True):
+    def created(app_name, output=None, app_data=None, path=Settings.TEST_RUN_HOME, webpack=True, theme=True):
         """
         Verify app is created properly.
         :param app_name: Name of the app.
@@ -33,31 +33,33 @@ class TnsAssert(object):
             assert 'After that you can run it on device/emulator by executing $ tns run <platform>' not in output
             assert 'Project {0} was successfully created'.format(app) in output, 'Failed to create {0}'.format(app)
 
-        # Assert app data
-        if app_data is not None:
-            # Verify modules installed
-            node_path = TnsHelpers.get_app_node_modules_path(app_name=app_name, path=path)
-            assert Folder.exists(os.path.join(node_path, 'tns-core-modules')), '{N} theme do not exists in app.'
-            assert File.exists(os.path.join(node_path, 'tns-core-modules', 'tns-core-modules.d.ts'))
+        # Verify modules installed
+        node_path = TnsHelpers.get_app_node_modules_path(app_name=app_name, path=path)
+        assert Folder.exists(os.path.join(node_path, 'tns-core-modules')), '{N} theme do not exists in app.'
+        assert File.exists(os.path.join(node_path, 'tns-core-modules', 'tns-core-modules.d.ts'))
 
-            # Verify {N} core theme is installed
-            if theme:
-                assert Folder.exists(os.path.join(node_path, 'nativescript-theme-core')), '{N} theme do not exists.'
+        # Verify {N} core theme is installed
+        if theme:
+            assert Folder.exists(os.path.join(node_path, 'nativescript-theme-core')), '{N} theme do not exists.'
 
-            # Verify webpack is installed
+        # Verify webpack is installed
+        if webpack:
             before_watch_hooks = os.path.join(app_path, 'hooks', 'before-watch')
             assert Folder.exists(os.path.join(node_path, 'nativescript-dev-webpack')), 'Webpack not installed in app.'
             assert File.exists(os.path.join(app_path, 'webpack.config.js')), 'Missing webpack config.'
             assert File.exists(os.path.join(before_watch_hooks, 'nativescript-dev-webpack.js')), 'Hooks not installed.'
 
-            # Verify typescript in TS and NG apps:
-            if app_data.app_type in {AppType.TS, AppType.NG, AppType.SHARED_NG}:
-                assert Folder.exists(os.path.join(node_path, 'nativescript-dev-typescript')), 'TS not installed in app.'
-                assert File.exists(os.path.join(app_path, 'tsconfig.json')), 'Missing config.'
+        # Verify typescript in TS and NG apps:
+        if app_data.app_type in {AppType.TS, AppType.NG, AppType.SHARED_NG}:
+            assert Folder.exists(os.path.join(node_path, 'nativescript-dev-typescript')), 'TS not installed in app.'
+            assert File.exists(os.path.join(app_path, 'tsconfig.json')), 'Missing config.'
+            if webpack:
                 assert File.exists(os.path.join(app_path, 'tsconfig.tns.json')), 'Missing config.'
-                assert File.exists(os.path.join(before_watch_hooks, 'nativescript-dev-typescript.js')), \
-                    'Hooks not installed.'
+            assert File.exists(os.path.join(before_watch_hooks, 'nativescript-dev-typescript.js')), \
+                'Hooks not installed.'
 
+        # Assert app data
+        if app_data is not None:
             # Assert app id
             if app_data.bundle_id is not None:
                 pass

--- a/tests/code_sharing/ng_new_tests.py
+++ b/tests/code_sharing/ng_new_tests.py
@@ -101,15 +101,25 @@ class NGNewTests(TnsTest):
             else:
                 app_data = Apps.SCHEMATICS_SHARED
 
+        # Create app
+        NGNewTests.create_app(app_data=app_data, shared=shared, sample=sample, theme=theme, style=style,
+                              prefix=prefix, source_dir=source_dir, webpack=webpack)
+
+        # Update the app
+        if Settings.ENV != EnvironmentType.LIVE:
+            App.update(app_name=NGNewTests.app_name, modules=True, angular=True, typescript=False, web_pack=False)
+
+        # Run the app
+        NGNewTests.run_bundle(app_data=app_data, webpack=webpack, shared=shared, theme=theme)
+
+    @staticmethod
+    def create_app(app_data, shared, sample, theme, style, prefix, source_dir, webpack):
         # Create shared project with sample data
         result = NG.new(collection=NS_SCHEMATICS, project=NGNewTests.app_name, theme=theme, shared=shared,
                         sample=sample, style=style, prefix=prefix, source_dir=source_dir, webpack=webpack)
 
         # Verify valid {N} app is created
-        theme = True
-        if style is None:
-            theme = False
-        TnsAssert.created(app_name=NGNewTests.app_name, app_data=app_data, theme=theme)
+        TnsAssert.created(app_name=NGNewTests.app_name, app_data=app_data, theme=theme, webpack=webpack)
         assert 'Directory is already under version control. Skipping initialization of git.' in result.output, \
             'Git init should be skipped because app is created already existing repo (the one with tests).'
 
@@ -152,10 +162,8 @@ class NGNewTests(TnsTest):
                 source_dir = 'src'
             assert Folder.exists(os.path.join(Settings.TEST_RUN_HOME, NGNewTests.app_name, source_dir))
 
-        # Update the app
-        if Settings.ENV != EnvironmentType.LIVE:
-            App.update(app_name=NGNewTests.app_name, modules=True, angular=True, typescript=False, web_pack=False)
-
+    @staticmethod
+    def run_bundle(app_data, webpack, shared, theme):
         # Run android (if webpack is available -> use --bundle)
         Tns.run(app_name=NGNewTests.app_name, platform=Platform.ANDROID, emulator=True, bundle=webpack)
         for text in app_data.texts:


### PR DESCRIPTION
Introduce `webpack` param in TnsAssert.created().
Fix code sharing tests.