### PR TITLE
fix: encoding issues on systems with python3

### DIFF
--- a/core/utils/file_utils.py
+++ b/core/utils/file_utils.py
@@ -103,13 +103,21 @@ class File(object):
 
     @staticmethod
     def write(path, text):
-        with open(path, 'w+') as text_file:
-            text_file.write(text)
+        if Settings.PYTHON_VERSION < 3:
+            with open(path, 'w+') as text_file:
+                text_file.write(text)
+        else:
+            with open(path, 'w+', encoding='utf-8', errors='ignore') as text_file:
+                text_file.write(text)
 
     @staticmethod
     def append(path, text):
-        with open(path, 'a') as text_file:
-            text_file.write(text)
+        if Settings.PYTHON_VERSION < 3:
+            with open(path, 'a') as text_file:
+                text_file.write(text)
+        else:
+            with open(path, 'a', encoding='utf-8', errors='ignore') as text_file:
+                text_file.write(text)
 
     @staticmethod
     def replace(path, old_string, new_string):

--- a/core_tests/utils/image_tests.py
+++ b/core_tests/utils/image_tests.py
@@ -11,6 +11,7 @@ import unittest
 
 import numpy
 
+from core.enums.os_type import OSType
 from core.settings import Settings
 from core.utils.image_utils import ImageUtils
 
@@ -36,6 +37,7 @@ class ImageUtilsTests(unittest.TestCase):
         assert (actual_color == self.white).all(), 'Main color is wrong. It should be white.'
 
     @unittest.skipIf(os.environ.get('TRAVIS', None) is not None, 'Skip on Travis.')
+    @unittest.skipIf(Settings.HOST_OS == OSType.WINDOWS, 'Skip on Windows.')
     def test_04_get_text(self):
         # OCR on Hello-World app
         text = ImageUtils.get_text(self.app_image)


### PR DESCRIPTION
We have some failures on Windows with Python3:
```
Traceback (most recent call last):
  File "C:\Python37\lib\unittest\case.py", line 59, in testPartExecutor
    yield
  File "C:\Python37\lib\unittest\case.py", line 615, in run
    testMethod()
  File "C:\Jenkins\workspace\master-cli-templates-windows\tests\cli\run\templates\hello_word_js_tests.py", line 62, in test_200_run_android_bundle
    sync_hello_world_js(self.app_name, Platform.ANDROID, self.emu, bundle=True)
  File "C:\Jenkins\workspace\master-cli-templates-windows\data\sync\hello_world_js.py", line 20, in sync_hello_world_js
    bundle=bundle, hmr=hmr, uglify=uglify, aot=aot, snapshot=snapshot)
  File "C:\Jenkins\workspace\master-cli-templates-windows\data\sync\hello_world_js.py", line 77, in __sync_hello_world_js_ts
    Sync.replace(app_name=app_name, change_set=css_change)
  File "C:\Jenkins\workspace\master-cli-templates-windows\data\changes.py", line 24, in replace
    File.replace(path=path, old_string=change_set.old_value, new_string=change_set.new_value)
  File "C:\Jenkins\workspace\master-cli-templates-windows\core\utils\file_utils.py", line 118, in replace
    File.write(path=path, text=new_content)
  File "C:\Jenkins\workspace\master-cli-templates-windows\core\utils\file_utils.py", line 107, in write
    text_file.write(text)
  File "C:\Python37\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\ufeff' in position 0: character maps to <undefined>
```
This PR is attepmt to resolve them.