### PR TITLE
feat: migrate regression tests

### DIFF
--- a/data/legacy_app.py
+++ b/data/legacy_app.py
@@ -1,0 +1,36 @@
+import os
+
+from core.enums.app_type import AppType
+from core.enums.os_type import OSType
+from core.settings import Settings
+from core.utils.npm import Npm
+from products.nativescript.app import App
+from products.nativescript.tns import Tns
+
+
+class LegacyApp(object):
+    @staticmethod
+    def create(app_name, app_type):
+        """
+         Create hello-world app based on {N} 4.2
+        :param app_name: App name.
+        :param app_type: AppType enum value.
+        """
+        template = 'tns-template-hello-world'
+        if app_type == AppType.NG:
+            template = template + '-ng'
+        if app_type == AppType.TS:
+            template = template + '-ts'
+        Tns.create(app_name=app_name, template='{0}@4.2'.format(template), update=False, verify=False)
+        assert '~4.2.' in App.get_package_json(app_name=app_name).get('dependencies').get('tns-core-modules')
+        if app_type == AppType.NG:
+            assert '~6.1.' in App.get_package_json(app_name=app_name).get('dependencies').get('nativescript-angular')
+            assert '~6.1.' in App.get_package_json(app_name=app_name).get('dependencies').get('@angular/core')
+        # Add platforms
+        Tns.platform_add_android(app_name=app_name, version='4.2')
+        if Settings.HOST_OS == OSType.OSX:
+            Tns.platform_add_ios(app_name=app_name, version='4.2')
+        # Install webpack
+        Npm.install(package='nativescript-dev-webpack@0.16', option='--save-dev',
+                    folder=os.path.join(Settings.TEST_RUN_HOME, app_name))
+        Npm.install(folder=os.path.join(Settings.TEST_RUN_HOME, app_name))

--- a/tests/cli/regression/test_js_regressions.py
+++ b/tests/cli/regression/test_js_regressions.py
@@ -1,0 +1,50 @@
+import unittest
+
+from core.base_test.tns_test import TnsTest
+from core.enums.app_type import AppType
+from core.enums.os_type import OSType
+from core.enums.platform_type import Platform
+from core.settings import Settings
+from core.utils.device.device_manager import DeviceManager
+from data.legacy_app import LegacyApp
+from data.sync.hello_world_js import sync_hello_world_js
+from products.nativescript.tns import Tns
+
+
+class JSRegressionTests(TnsTest):
+    emu = None
+    sim = None
+    js_app = Settings.AppName.DEFAULT + 'JS'
+
+    @classmethod
+    def setUpClass(cls):
+        TnsTest.setUpClass()
+
+        # Boot emulator and simulator
+        cls.emu = DeviceManager.Emulator.ensure_available(Settings.Emulators.DEFAULT)
+        if Settings.HOST_OS == OSType.OSX:
+            cls.sim = DeviceManager.Simulator.ensure_available(Settings.Simulators.DEFAULT)
+
+        # Create legacy JS app
+        LegacyApp.create(app_name=cls.js_app, app_type=AppType.JS)
+
+    def setUp(self):
+        TnsTest.setUp(self)
+
+    @classmethod
+    def tearDownClass(cls):
+        TnsTest.tearDownClass()
+
+    def test_100_run_android(self):
+        sync_hello_world_js(app_name=self.js_app, platform=Platform.ANDROID, device=self.emu)
+
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_101_run_ios(self):
+        sync_hello_world_js(app_name=self.js_app, platform=Platform.IOS, device=self.sim)
+
+    def test_200_build_android_release(self):
+        Tns.build_android(app_name=self.js_app, release=True, bundle=True, aot=True, uglify=True, snapshot=True)
+
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_201_build_ios_release(self):
+        Tns.build_ios(app_name=self.js_app, release=True, for_device=True, bundle=True, aot=True, uglify=True)

--- a/tests/cli/regression/test_ng_regressions.py
+++ b/tests/cli/regression/test_ng_regressions.py
@@ -1,0 +1,50 @@
+import unittest
+
+from core.base_test.tns_test import TnsTest
+from core.enums.app_type import AppType
+from core.enums.os_type import OSType
+from core.enums.platform_type import Platform
+from core.settings import Settings
+from core.utils.device.device_manager import DeviceManager
+from data.legacy_app import LegacyApp
+from data.sync.hello_world_ng import sync_hello_world_ng
+from products.nativescript.tns import Tns
+
+
+class NGRegressionTests(TnsTest):
+    emu = None
+    sim = None
+    ng_app = Settings.AppName.DEFAULT + 'NG'
+
+    @classmethod
+    def setUpClass(cls):
+        TnsTest.setUpClass()
+
+        # Boot emulator and simulator
+        cls.emu = DeviceManager.Emulator.ensure_available(Settings.Emulators.DEFAULT)
+        if Settings.HOST_OS == OSType.OSX:
+            cls.sim = DeviceManager.Simulator.ensure_available(Settings.Simulators.DEFAULT)
+
+        # Create legacy NG app
+        LegacyApp.create(app_name=cls.ng_app, app_type=AppType.NG)
+
+    def setUp(self):
+        TnsTest.setUp(self)
+
+    @classmethod
+    def tearDownClass(cls):
+        TnsTest.tearDownClass()
+
+    def test_100_run_android(self):
+        sync_hello_world_ng(app_name=self.ng_app, platform=Platform.ANDROID, device=self.emu)
+
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_101_run_ios(self):
+        sync_hello_world_ng(app_name=self.ng_app, platform=Platform.IOS, device=self.sim)
+
+    def test_200_build_android_release(self):
+        Tns.build_android(app_name=self.ng_app, release=True, bundle=True, aot=True, uglify=True, snapshot=True)
+
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_201_build_ios_release(self):
+        Tns.build_ios(app_name=self.ng_app, release=True, for_device=True, bundle=True, aot=True, uglify=True)

--- a/tests/cli/smoke/smoke_tests.py
+++ b/tests/cli/smoke/smoke_tests.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 
 from core.base_test.tns_test import TnsTest
@@ -14,12 +13,7 @@ from products.nativescript.tns import Tns
 
 class SmokeTests(TnsTest):
     js_app = Settings.AppName.DEFAULT + 'JS'
-    js_source_project_dir = os.path.join(Settings.TEST_RUN_HOME, js_app)
-    js_target_project_dir = os.path.join(Settings.TEST_RUN_HOME, 'data', 'temp', js_app)
-
     ng_app = Settings.AppName.DEFAULT + 'NG'
-    ng_source_project_dir = os.path.join(Settings.TEST_RUN_HOME, ng_app)
-    ng_target_project_dir = os.path.join(Settings.TEST_RUN_HOME, 'data', 'temp', ng_app)
 
     emu = None
     sim = None


### PR DESCRIPTION
Migrate regression tests:
https://github.com/NativeScript/nativescript-cli-tests/tree/master/tests/regression

Changes that happened during migration:
- Tests backward compatiblity with 4.2 (instead of 4.1)
- Generate 4.2 app with CLI under test (do not bring old project with tests).