### PR TITLE
feat: migrate misc tests

### DIFF
--- a/core/base_test/tns_test.py
+++ b/core/base_test/tns_test.py
@@ -1,3 +1,5 @@
+# pylint: disable=broad-except
+import inspect
 import os
 import unittest
 
@@ -14,11 +16,15 @@ from core.utils.xcode import Xcode
 from products.nativescript.tns import Tns
 
 
+# noinspection PyBroadException
 class TnsTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # Get class name and log
-        TestContext.CLASS_NAME = cls.__name__
+        try:
+            TestContext.CLASS_NAME = inspect.stack()[1][0].f_locals['cls'].__name__
+        except:
+            TestContext.CLASS_NAME = cls.__name__
         Log.test_class_start(class_name=TestContext.CLASS_NAME)
 
         # Kill processes

--- a/core/base_test/tns_test.py
+++ b/core/base_test/tns_test.py
@@ -23,7 +23,7 @@ class TnsTest(unittest.TestCase):
         # Get class name and log
         try:
             TestContext.CLASS_NAME = inspect.stack()[1][0].f_locals['cls'].__name__
-        except:
+        except Exception:
             TestContext.CLASS_NAME = cls.__name__
         Log.test_class_start(class_name=TestContext.CLASS_NAME)
 

--- a/core/base_test/tns_test.py
+++ b/core/base_test/tns_test.py
@@ -1,4 +1,3 @@
-import inspect
 import os
 import unittest
 
@@ -19,7 +18,7 @@ class TnsTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # Get class name and log
-        TestContext.CLASS_NAME = inspect.stack()[1][0].f_locals['cls'].__name__
+        TestContext.CLASS_NAME = cls.__name__
         Log.test_class_start(class_name=TestContext.CLASS_NAME)
 
         # Kill processes
@@ -78,7 +77,7 @@ class TnsTest(unittest.TestCase):
         Tns.kill()
         TnsTest.kill_emulators()
         Process.kill_all_in_context()
-        Log.test_class_end(class_name=cls.__name__)
+        Log.test_class_end(TestContext.CLASS_NAME)
 
     @staticmethod
     def kill_emulators():

--- a/tests/cli/misc/autocomplete_tests.py
+++ b/tests/cli/misc/autocomplete_tests.py
@@ -1,0 +1,43 @@
+"""
+Test for autocomplete command
+"""
+from core.base_test.tns_test import TnsTest
+from products.nativescript.tns import Tns
+
+
+# noinspection PyMethodMayBeStatic
+class AutocompleteTests(TnsTest):
+    changed_to_enable = 'Restart your shell to enable command auto-completion.'
+    changed_to_disable = 'Restart your shell to disable command auto-completion.'
+    already_enabled = 'Autocompletion is already enabled.'
+    enabled = 'Autocompletion is enabled.'
+    disabled = 'Autocompletion is disabled.'
+
+    def test_001_autocomplete_enable_and_disable(self):
+        # Force enable autocomplete.
+        Tns.exec_command(command='autocomplete enable')
+
+        # Verify status
+        result = Tns.exec_command(command='autocomplete status')
+        assert self.enabled in result.output
+
+        # Disable autocomplete.
+        result = Tns.exec_command(command='autocomplete disable')
+        assert self.changed_to_disable in result.output
+
+        # Verify status
+        result = Tns.exec_command(command='autocomplete status')
+        assert self.disabled in result.output
+
+        # Enable again
+        result = Tns.exec_command(command='autocomplete enable')
+        assert self.changed_to_enable in result.output
+
+        # Enable once again
+        result = Tns.exec_command(command='autocomplete enable')
+        assert self.already_enabled in result.output
+
+    def test_400_autocomplete_invalid_parameter(self):
+        result = Tns.exec_command(command='autocomplete fake')
+        assert "This command doesn't accept parameters." in result.output
+        assert 'This operation might modify the .bash_profile, .bashrc and .zshrc files.' in result.output

--- a/tests/cli/misc/error_reporting_tests.py
+++ b/tests/cli/misc/error_reporting_tests.py
@@ -1,0 +1,26 @@
+"""
+Test for error-reporting command
+"""
+from core.base_test.tns_test import TnsTest
+from products.nativescript.tns import Tns
+
+
+# noinspection PyMethodMayBeStatic
+class ErrorReportingTests(TnsTest):
+
+    def test_001_error_reporting_enable(self):
+        result = Tns.exec_command(command='error-reporting enable')
+        assert 'Error reporting is now enabled.' in result.output
+        result = Tns.exec_command(command='error-reporting status')
+        assert 'Error reporting is enabled.' in result.output
+
+    def test_002_error_reporting_disable(self):
+        result = Tns.exec_command(command='error-reporting disable')
+        assert 'Error reporting is now disabled.' in result.output
+        result = Tns.exec_command(command='error-reporting status')
+        assert 'Error reporting is disabled.' in result.output
+
+    def test_401_error_reporting_with_invalid_parameter(self):
+        result = Tns.exec_command(command='error-reporting fake')
+        assert "The value 'fake' is not valid" in result.output
+        assert "Valid values are 'enable', 'disable' and 'status'." in result.output

--- a/tests/cli/misc/misc.md
+++ b/tests/cli/misc/misc.md
@@ -1,8 +1,5 @@
 #Tests to be writen
 
-**autocomplete**
-https://github.com/NativeScript/nativescript-cli/blob/master/docs/man_pages/general/autocomplete.md
-
 **setup**
 https://github.com/NativeScript/nativescript-cli/blob/master/docs/man_pages/env-configuration/setup.md
 

--- a/tests/cli/misc/pacakge_manager_tests.py
+++ b/tests/cli/misc/pacakge_manager_tests.py
@@ -1,23 +1,12 @@
+"""
+Test for package-manager command
+"""
 from core.base_test.tns_test import TnsTest
 from products.nativescript.tns import Tns
 
 
 # noinspection PyMethodMayBeStatic
 class PackageManagerTests(TnsTest):
-
-    @classmethod
-    def setUpClass(cls):
-        TnsTest.setUpClass()
-
-    def setUp(self):
-        TnsTest.setUp(self)
-
-    def tearDown(self):
-        TnsTest.tearDown(self)
-
-    @classmethod
-    def tearDownClass(cls):
-        TnsTest.tearDownClass()
 
     def test_001_package_manager_get(self):
         result = Tns.exec_command(command='package-manager get')

--- a/tests/cli/misc/setup_tests.py
+++ b/tests/cli/misc/setup_tests.py
@@ -1,0 +1,20 @@
+"""
+Test that check CLI package after installation.
+"""
+import os
+import unittest
+
+from core.base_test.tns_test import TnsTest
+from core.enums.os_type import OSType
+from core.settings import Settings
+from core.utils.run import run
+
+
+class SetupTests(TnsTest):
+
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'Skip on Linux and Windows')
+    def test_300_mac_script_has_execution_permissions(self):
+        script = os.path.join(Settings.TEST_RUN_HOME,
+                              'node_modules', 'nativescript', 'setup', 'mac-startup-shell-script.sh')
+        result = run(cmd='ls -la {0}'.format(script))
+        assert '-rwxr-xr-x' in result.output, 'macOS script has not execution permissions.'

--- a/tests/cli/misc/version_tests.py
+++ b/tests/cli/misc/version_tests.py
@@ -1,0 +1,16 @@
+"""
+Test for `tns --version` command
+"""
+import re
+
+from core.base_test.tns_test import TnsTest
+from products.nativescript.tns import Tns
+
+
+# noinspection PyMethodMayBeStatic
+class VersionTests(TnsTest):
+
+    def test_001_version(self):
+        version = Tns.version()
+        match = re.compile("^\\d+\\.\\d+\\.\\d+(-\\S+)?$").match(version)
+        assert match, "{0} is not a valid version.".format(version)


### PR DESCRIPTION
Migrated tests:
- autocomplete
- error reporting
- setup
- version

Features in core:
- Fix get class name
- Enable creating test classes based on TnsTests without specifying setUp and tearDown methods

How tests was looking before:
```
class MyTestClass(TnsTest):

    @classmethod
    def setUpClass(cls):
        TnsTest.setUpClass()

    def setUp(self):
        TnsTest.setUp(self)

   def tearDown(self):
        TnsTest.tearDown(self)

    @classmethod
    def tearDownClass(cls):
        TnsTest.tearDownClass()

    def test_hello(self):
        pass
```

Example how simple test can look like now (and hooks in base class are still executed):
```
class MyTestClass(TnsTest):

    def test_hello(self):
        pass
```
