### PR TITLE
feat: use emulator snapshots

### DIFF
--- a/core/utils/device/device_manager.py
+++ b/core/utils/device/device_manager.py
@@ -7,6 +7,7 @@ from core.utils.device.adb import Adb, ANDROID_HOME
 from core.utils.device.device import Device
 from core.utils.device.idevice import IDevice
 from core.utils.device.simctl import Simctl
+from core.utils.file_utils import Folder
 from core.utils.process import Process
 from core.utils.run import run
 
@@ -51,12 +52,20 @@ class DeviceManager(object):
             Process.kill('qemu-system-i38')
 
         @staticmethod
-        def start(emulator, wipe_data=True):
+        def start(emulator):
+            # Define emulator start options and command
             emulator_path = os.path.join(ANDROID_HOME, 'emulator', 'emulator')
-            base_options = '-no-snapshot-save -no-boot-anim -no-audio'
-            options = '-port {0} {1}'.format(emulator.port, base_options)
-            if wipe_data:
-                options = '-port {0} -wipe-data {1}'.format(emulator.port, base_options)
+            options = '-port {0} -wipe-data -no-snapshot-save -no-boot-anim -no-audio'.format(emulator.port)
+
+            # Check if clean snapshot is available and use it
+            snapshot_name = 'clean_boot'
+            home = os.path.expanduser("~")
+            snapshot = os.path.join(home, '.android', 'avd', '{0}.avd'.format(emulator.avd), 'snapshots', snapshot_name)
+            if Folder.exists(snapshot):
+                Log.info('{0} has clean boot snapshot! Will user it.'.format(emulator.avd))
+                options = '-port {0} -no-snapshot-save -no-boot-anim -no-audio -snapshot {1}'.format(emulator.port,
+                                                                                                     snapshot_name)
+
             command = '{0} @{1} {2}'.format(emulator_path, emulator.avd, options)
             Log.info('Booting {0} with cmd:'.format(emulator.avd))
             Log.info(command)

--- a/core/utils/file_utils.py
+++ b/core/utils/file_utils.py
@@ -3,9 +3,8 @@ File and Folder utils.
 """
 import errno
 import os
-import stat
-
 import shutil
+import stat
 
 from core.log.log import Log
 from core.settings import Settings
@@ -122,6 +121,7 @@ class File(object):
     @staticmethod
     def replace(path, old_string, new_string):
         content = File.read(path=path)
+        assert old_string in content, 'Can not find "{0}" in {1}'.format(old_string, path)
         new_content = content.replace(old_string, new_string)
         File.write(path=path, text=new_content)
         Log.info("")

--- a/core_tests/device/adb_tests.py
+++ b/core_tests/device/adb_tests.py
@@ -15,7 +15,7 @@ class AdbTests(TnsTest):
     def setUpClass(cls):
         TnsTest.setUpClass()
         DeviceManager.Emulator.stop()
-        cls.emu = DeviceManager.Emulator.start(Settings.Emulators.DEFAULT, wipe_data=True)
+        cls.emu = DeviceManager.Emulator.start(Settings.Emulators.DEFAULT)
 
     def setUp(self):
         TnsTest.setUp(self)

--- a/tests/runtimes/android/error_activity_tests.py
+++ b/tests/runtimes/android/error_activity_tests.py
@@ -36,12 +36,12 @@ class AndroidErrorActivityTests(TnsTest):
 
     def test_200_error_activity_shown_on_error(self):
         Tns.run_android(app_name=APP_NAME, emulator=True, wait=False)
-        self.emu.wait_for_text('Exception', timeout=180, retry_delay=10), 'Error activity not found on device!'
-        self.emu.wait_for_text('Logcat'), 'Error activity not found on device!'
-        self.emu.wait_for_text('Error: Kill the app!'), 'Error activity not found on device!'
+        self.emu.wait_for_text('Exception', timeout=180, retry_delay=10)
+        self.emu.wait_for_text('Logcat')
+        self.emu.wait_for_text('Error: Kill the app!')
         # TODO: Verify stack trace of the error is printed in console (waiting nativescript-tooling-qa/pull/26).
 
     def test_400_no_error_activity_in_release_builds(self):
         Tns.run_android(app_name=APP_NAME, release=True, emulator=True, wait=False)
-        self.emu.wait_for_text('Unfortunately', timeout=180, retry_delay=10), 'No error that app crashed!'
-        self.emu.is_text_visible('Exception'), 'Error activity found on device!'
+        self.emu.wait_for_text('Unfortunately', timeout=180, retry_delay=10)
+        self.emu.is_text_visible('Exception')

--- a/tests/runtimes/android/error_activity_tests.py
+++ b/tests/runtimes/android/error_activity_tests.py
@@ -1,0 +1,47 @@
+"""
+Test for android error activity.
+
+Verify that:
+ - If error happens error activity is displayed (debug mode).
+ - Stack trace of the error is printed in console.
+ - No error activity in release builds.
+"""
+import os
+
+from core.base_test.tns_test import TnsTest
+from core.settings import Settings
+from core.utils.device.device_manager import DeviceManager
+from data.changes import Sync, ChangeSet
+from data.templates import Template
+from products.nativescript.tns import Tns
+
+APP_NAME = Settings.AppName.DEFAULT
+
+
+class AndroidErrorActivityTests(TnsTest):
+    @classmethod
+    def setUpClass(cls):
+        TnsTest.setUpClass()
+        Tns.create(app_name=APP_NAME, template=Template.HELLO_WORLD_JS.local_package, update=True)
+        Tns.platform_add_android(app_name=APP_NAME, framework_path=Settings.Android.FRAMEWORK_PATH)
+
+        # Break the app to test error activity
+        change = ChangeSet(file_path=os.path.join(Settings.TEST_RUN_HOME, APP_NAME, 'app', 'app.js'),
+                           old_value='application.run({ moduleName: "app-root" });',
+                           new_value='throw new Error("Kill the app!");')
+        Sync.replace(app_name=APP_NAME, change_set=change)
+
+        # Start emulator
+        cls.emu = DeviceManager.Emulator.ensure_available(Settings.Emulators.DEFAULT)
+
+    def test_200_error_activity_shown_on_error(self):
+        Tns.run_android(app_name=APP_NAME, emulator=True, wait=False)
+        self.emu.wait_for_text('Exception', timeout=180, retry_delay=10), 'Error activity not found on device!'
+        self.emu.wait_for_text('Logcat'), 'Error activity not found on device!'
+        self.emu.wait_for_text('Error: Kill the app!'), 'Error activity not found on device!'
+        # TODO: Verify stack trace of the error is printed in console (waiting nativescript-tooling-qa/pull/26).
+
+    def test_400_no_error_activity_in_release_builds(self):
+        Tns.run_android(app_name=APP_NAME, release=True, emulator=True, wait=False)
+        self.emu.wait_for_text('Unfortunately', timeout=180, retry_delay=10), 'No error that app crashed!'
+        self.emu.is_text_visible('Exception'), 'Error activity found on device!'

--- a/tests/runtimes/android/todo.md
+++ b/tests/runtimes/android/todo.md
@@ -1,0 +1,2 @@
+# TODOs:
+- Write tests for android runtime

--- a/tests/runtimes/ios/todo.md
+++ b/tests/runtimes/ios/todo.md
@@ -1,0 +1,2 @@
+# TODOs:
+- Write tests for ios runtime


### PR DESCRIPTION
Feat:
- Use emulator snapshot named `clean_boot` (if available)

Fix:
- File.repalce() will now fail if old tests is not available in file

Added Tests:
- Error activity tests