### PR TITLE
feat: introduce base TnsRunTest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ script:
   - python -m nose core_tests/unit -v -s --nologcapture --with-doctest --with-xunit
   - python -m flake8 --max-line-length=120 core core_tests data products tests
   - python -m pylint --disable=locally-disabled --rcfile=.pylintrc core data products
-  - find core_tests | grep .py | grep -v .pyc | xargs python -m pylint --disable=locally-disabled --min-similarity-lines=15 --rcfile=.pylintrc
+  - find core_tests | grep .py | grep -v .pyc | xargs python -m pylint --disable=locally-disabled --rcfile=.pylintrc
   - find tests | grep .py | grep -v .pyc | xargs python -m pylint --disable=locally-disabled --min-similarity-lines=15 --rcfile=.pylintrc

--- a/HINTS.md
+++ b/HINTS.md
@@ -8,6 +8,15 @@
 Preference -> Tools -> Python integrated Tools - Choose Nosetests as Default test runner
 ```
 
+## Xcode Commandline Tools
+
+### xcrun simctl
+`xcrun simctl` tutorial:
+- https://www.iosdev.recipes/simctl/
+
+### Disable accept trafic messages in iOS Simulator
+- https://tomsoderling.github.io/Disable-iOS-simulator-connections-popup/
+
 ## Android Commandline Tools
 
 ### Emulator Quick Boot

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ python -m pylint --disable=locally-disabled --rcfile=.pylintrc core data product
 Due to the fact tests are not modules pylint can not be executed directly.
 Workaround:
 ```bash
-find core_tests | grep .py | grep -v .pyc | xargs python -m pylint --disable=locally-disabled --min-similarity-lines=15 --rcfile=.pylintrc
+find core_tests | grep .py | grep -v .pyc | xargs python -m pylint --disable=locally-disabled --rcfile=.pylintrc
 find tests | grep .py | grep -v .pyc | xargs python -m pylint --disable=locally-disabled --min-similarity-lines=15 --rcfile=.pylintrc
 ```
 

--- a/core/base_test/tns_run_android_test.py
+++ b/core/base_test/tns_run_android_test.py
@@ -1,0 +1,15 @@
+from core.base_test.tns_test import TnsTest
+from core.settings import Settings
+from core.utils.device.adb import Adb
+from core.utils.device.device_manager import DeviceManager
+
+
+class TnsRunAndroidTest(TnsTest):
+    @classmethod
+    def setUpClass(cls):
+        TnsTest.setUpClass()
+        cls.emu = DeviceManager.Emulator.ensure_available(Settings.Emulators.DEFAULT)
+
+    def setUp(self):
+        TnsTest.setUp(self)
+        Adb.open_home(self.emu.id)

--- a/core/base_test/tns_run_ios_test.py
+++ b/core/base_test/tns_run_ios_test.py
@@ -1,0 +1,10 @@
+from core.base_test.tns_test import TnsTest
+from core.settings import Settings
+from core.utils.device.device_manager import DeviceManager
+
+
+class TnsRunIOSTest(TnsTest):
+    @classmethod
+    def setUpClass(cls):
+        TnsTest.setUpClass()
+        cls.sim = DeviceManager.Simulator.ensure_available(Settings.Simulators.DEFAULT)

--- a/core/base_test/tns_run_ios_test.py
+++ b/core/base_test/tns_run_ios_test.py
@@ -1,6 +1,7 @@
 from core.base_test.tns_test import TnsTest
 from core.settings import Settings
 from core.utils.device.device_manager import DeviceManager
+from core.utils.device.simctl import Simctl
 
 
 class TnsRunIOSTest(TnsTest):
@@ -8,3 +9,8 @@ class TnsRunIOSTest(TnsTest):
     def setUpClass(cls):
         TnsTest.setUpClass()
         cls.sim = DeviceManager.Simulator.ensure_available(Settings.Simulators.DEFAULT)
+        Simctl.uninstall_all(cls.sim)
+
+    def setUp(self):
+        TnsTest.setUp(self)
+        Simctl.stop_all(self.sim)

--- a/core/base_test/tns_run_test.py
+++ b/core/base_test/tns_run_test.py
@@ -3,6 +3,7 @@ from core.enums.os_type import OSType
 from core.settings import Settings
 from core.utils.device.adb import Adb
 from core.utils.device.device_manager import DeviceManager
+from core.utils.device.simctl import Simctl
 
 
 class TnsRunTest(TnsTest):
@@ -13,7 +14,9 @@ class TnsRunTest(TnsTest):
         cls.emu = DeviceManager.Emulator.ensure_available(Settings.Emulators.DEFAULT)
         if Settings.HOST_OS is OSType.OSX:
             cls.sim = DeviceManager.Simulator.ensure_available(Settings.Simulators.DEFAULT)
+            Simctl.uninstall_all(cls.sim)
 
     def setUp(self):
         TnsTest.setUp(self)
         Adb.open_home(self.emu.id)
+        Simctl.stop_all(self.sim)

--- a/core/base_test/tns_run_test.py
+++ b/core/base_test/tns_run_test.py
@@ -1,0 +1,19 @@
+from core.base_test.tns_test import TnsTest
+from core.enums.os_type import OSType
+from core.settings import Settings
+from core.utils.device.adb import Adb
+from core.utils.device.device_manager import DeviceManager
+
+
+class TnsRunTest(TnsTest):
+
+    @classmethod
+    def setUpClass(cls):
+        TnsTest.setUpClass()
+        cls.emu = DeviceManager.Emulator.ensure_available(Settings.Emulators.DEFAULT)
+        if Settings.HOST_OS is OSType.OSX:
+            cls.sim = DeviceManager.Simulator.ensure_available(Settings.Simulators.DEFAULT)
+
+    def setUp(self):
+        TnsTest.setUp(self)
+        Adb.open_home(self.emu.id)

--- a/core_tests/e2e/core/test_base_tns_run_test.py
+++ b/core_tests/e2e/core/test_base_tns_run_test.py
@@ -1,0 +1,9 @@
+from core.base_test.tns_run_test import TnsRunTest
+from core.log.log import Log
+
+
+class TestTnsRunBaseTest(TnsRunTest):
+
+    def test_smoke(self):
+        Log.info(self.emu.get_text())
+        Log.info(self.sim.get_text())

--- a/data/sync/hello_world_ng.py
+++ b/data/sync/hello_world_ng.py
@@ -10,8 +10,9 @@ from data.const import Colors
 from products.nativescript.tns import Tns
 
 
-def sync_hello_world_ng(app_name, platform, device, bundle=False, uglify=False, aot=False):
-    Tns.run(app_name=app_name, platform=platform, emulator=True, wait=False, bundle=bundle, aot=aot, uglify=uglify)
+def sync_hello_world_ng(app_name, platform, device, bundle=False, uglify=False, aot=False, hmr=False):
+    Tns.run(app_name=app_name, platform=platform, emulator=True, wait=False,
+            bundle=bundle, aot=aot, uglify=uglify, hmr=hmr)
     # Verify it looks properly
     device.wait_for_text(text=Changes.NGHelloWorld.TS.old_text, timeout=300, retry_delay=5)
     device.wait_for_main_color(color=Colors.WHITE)

--- a/tests/cli/run/templates/hello_word_js_tests.py
+++ b/tests/cli/run/templates/hello_word_js_tests.py
@@ -1,33 +1,24 @@
 import os
 import unittest
 
-from core.base_test.tns_test import TnsTest
+from core.base_test.tns_run_test import TnsRunTest
 from core.enums.os_type import OSType
 from core.enums.platform_type import Platform
 from core.settings import Settings
-from core.utils.device.adb import Adb
-from core.utils.device.device_manager import DeviceManager
 from core.utils.file_utils import Folder, File
 from data.sync.hello_world_js import sync_hello_world_js
 from data.templates import Template
 from products.nativescript.tns import Tns
 
 
-class TnsRunJSTests(TnsTest):
+class TnsRunJSTests(TnsRunTest):
     app_name = Settings.AppName.DEFAULT
     source_project_dir = os.path.join(Settings.TEST_RUN_HOME, app_name)
     target_project_dir = os.path.join(Settings.TEST_RUN_HOME, 'data', 'temp', app_name)
-    emu = None
-    sim = None
 
     @classmethod
     def setUpClass(cls):
-        TnsTest.setUpClass()
-
-        # Boot emulator and simulator
-        cls.emu = DeviceManager.Emulator.ensure_available(Settings.Emulators.DEFAULT)
-        if Settings.HOST_OS == OSType.OSX:
-            cls.sim = DeviceManager.Simulator.ensure_available(Settings.Simulators.DEFAULT)
+        TnsRunTest.setUpClass()
 
         # Create app
         Tns.create(app_name=cls.app_name, template=Template.HELLO_WORLD_JS.local_package, update=True)
@@ -42,9 +33,7 @@ class TnsRunJSTests(TnsTest):
         Folder.copy(source=cls.source_project_dir, target=cls.target_project_dir)
 
     def setUp(self):
-        TnsTest.setUp(self)
-        Adb.open_home(self.emu.id)
-
+        TnsRunTest.setUp(self)
         # "src" folder of TestApp will be restored before each test.
         # This will ensure failures in one test do not cause common failures.
         source_src = os.path.join(self.target_project_dir, 'app')
@@ -52,47 +41,48 @@ class TnsRunJSTests(TnsTest):
         Folder.clean(target_src)
         Folder.copy(source=source_src, target=target_src)
 
-
-class RunAndroidJSTests(TnsRunJSTests):
     def test_100_run_android(self):
         sync_hello_world_js(self.app_name, Platform.ANDROID, self.emu)
+
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_100_run_ios(self):
+        sync_hello_world_js(self.app_name, Platform.IOS, self.sim)
 
     def test_200_run_android_bundle(self):
         sync_hello_world_js(self.app_name, Platform.ANDROID, self.emu, bundle=True)
 
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_200_run_ios_bundle(self):
+        sync_hello_world_js(self.app_name, Platform.IOS, self.sim, bundle=True)
+
     def test_210_run_android_bundle_hmr(self):
         sync_hello_world_js(self.app_name, Platform.ANDROID, self.emu, hmr=True)
+
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_210_run_ios_bundle_hmr(self):
+        sync_hello_world_js(self.app_name, Platform.IOS, self.sim, hmr=True)
 
     def test_300_run_android_bundle_aot(self):
         sync_hello_world_js(self.app_name, Platform.ANDROID, self.emu, bundle=True, aot=True)
 
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_300_run_ios_bundle_aot(self):
+        sync_hello_world_js(self.app_name, Platform.IOS, self.sim, bundle=True, aot=True)
+
     def test_310_run_android_bundle_uglify(self):
         sync_hello_world_js(self.app_name, Platform.ANDROID, self.emu, bundle=True, uglify=True)
+
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_310_run_ios_bundle_uglify(self):
+        sync_hello_world_js(self.app_name, Platform.IOS, self.sim, bundle=True, uglify=True)
 
     def test_320_run_android_bundle_aot_and_uglify(self):
         sync_hello_world_js(self.app_name, Platform.ANDROID, self.emu, bundle=True, aot=True, uglify=True)
 
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_320_run_ios_bundle_aot_and_uglify(self):
+        sync_hello_world_js(self.app_name, Platform.IOS, self.sim, bundle=True, aot=True, uglify=True)
+
     def test_390_run_android_bundle_aot_uglify_snapshot(self):
         sync_hello_world_js(self.app_name, Platform.ANDROID, self.emu,
                             bundle=True, aot=True, uglify=True, snapshot=True)
-
-
-@unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
-class RunIOSJSTests(TnsRunJSTests):
-    def test_100_run_ios(self):
-        sync_hello_world_js(self.app_name, Platform.IOS, self.sim)
-
-    def test_200_run_ios_bundle(self):
-        sync_hello_world_js(self.app_name, Platform.IOS, self.sim, bundle=True)
-
-    def test_210_run_ios_bundle_hmr(self):
-        sync_hello_world_js(self.app_name, Platform.IOS, self.sim, hmr=True)
-
-    def test_300_run_ios_bundle_aot(self):
-        sync_hello_world_js(self.app_name, Platform.IOS, self.sim, bundle=True, aot=True)
-
-    def test_310_run_ios_bundle_uglify(self):
-        sync_hello_world_js(self.app_name, Platform.IOS, self.sim, bundle=True, uglify=True)
-
-    def test_320_run_ios_bundle_aot_and_uglify(self):
-        sync_hello_world_js(self.app_name, Platform.IOS, self.sim, bundle=True, aot=True, uglify=True)

--- a/tests/cli/run/templates/hello_word_ts_tests.py
+++ b/tests/cli/run/templates/hello_word_ts_tests.py
@@ -1,33 +1,24 @@
 import os
 import unittest
 
-from core.base_test.tns_test import TnsTest
+from core.base_test.tns_run_test import TnsRunTest
 from core.enums.os_type import OSType
 from core.enums.platform_type import Platform
 from core.settings import Settings
-from core.utils.device.adb import Adb
-from core.utils.device.device_manager import DeviceManager
 from core.utils.file_utils import Folder, File
 from data.sync.hello_world_js import sync_hello_world_ts
 from data.templates import Template
 from products.nativescript.tns import Tns
 
 
-class TnsRunTSTests(TnsTest):
+class TnsRunTSTests(TnsRunTest):
     app_name = Settings.AppName.DEFAULT
     source_project_dir = os.path.join(Settings.TEST_RUN_HOME, app_name)
     target_project_dir = os.path.join(Settings.TEST_RUN_HOME, 'data', 'temp', app_name)
-    emu = None
-    sim = None
 
     @classmethod
     def setUpClass(cls):
-        TnsTest.setUpClass()
-
-        # Boot emulator and simulator
-        cls.emu = DeviceManager.Emulator.ensure_available(Settings.Emulators.DEFAULT)
-        if Settings.HOST_OS == OSType.OSX:
-            cls.sim = DeviceManager.Simulator.ensure_available(Settings.Simulators.DEFAULT)
+        TnsRunTest.setUpClass()
 
         # Create app
         Tns.create(app_name=cls.app_name, template=Template.HELLO_WORLD_TS.local_package, update=True)
@@ -42,9 +33,7 @@ class TnsRunTSTests(TnsTest):
         Folder.copy(source=cls.source_project_dir, target=cls.target_project_dir)
 
     def setUp(self):
-        TnsTest.setUp(self)
-        Adb.open_home(self.emu.id)
-
+        TnsRunTest.setUp(self)
         # "src" folder of TestApp will be restored before each test.
         # This will ensure failures in one test do not cause common failures.
         source_src = os.path.join(self.target_project_dir, 'app')
@@ -52,8 +41,6 @@ class TnsRunTSTests(TnsTest):
         Folder.clean(target_src)
         Folder.copy(source=source_src, target=target_src)
 
-
-class RunAndroidTSTests(TnsRunTSTests):
     def test_100_run_android(self):
         sync_hello_world_ts(self.app_name, Platform.ANDROID, self.emu)
 
@@ -72,23 +59,26 @@ class RunAndroidTSTests(TnsRunTSTests):
     def test_320_run_android_bundle_aot_and_uglify(self):
         sync_hello_world_ts(self.app_name, Platform.ANDROID, self.emu, bundle=True, aot=True, uglify=True)
 
-
-@unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
-class RunIOSTSTests(TnsRunTSTests):
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_100_run_ios(self):
         sync_hello_world_ts(self.app_name, Platform.IOS, self.sim)
 
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_200_run_ios_bundle(self):
         sync_hello_world_ts(self.app_name, Platform.IOS, self.sim, bundle=True)
 
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_210_run_ios_bundle_hmr(self):
         sync_hello_world_ts(self.app_name, Platform.IOS, self.sim, bundle=True, hmr=True)
 
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_300_run_ios_bundle_aot(self):
         sync_hello_world_ts(self.app_name, Platform.IOS, self.sim, bundle=True, aot=True)
 
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_310_run_ios_bundle_uglify(self):
         sync_hello_world_ts(self.app_name, Platform.IOS, self.sim, bundle=True, uglify=True)
 
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_320_run_ios_bundle_aot_and_uglify(self):
         sync_hello_world_ts(self.app_name, Platform.IOS, self.sim, bundle=True, aot=True, uglify=True)

--- a/tests/cli/run/templates/hello_world_ng_tests.py
+++ b/tests/cli/run/templates/hello_world_ng_tests.py
@@ -1,33 +1,24 @@
 import os
 import unittest
 
-from core.base_test.tns_test import TnsTest
+from core.base_test.tns_run_test import TnsRunTest
 from core.enums.os_type import OSType
 from core.enums.platform_type import Platform
 from core.settings import Settings
-from core.utils.device.adb import Adb
-from core.utils.device.device_manager import DeviceManager
 from core.utils.file_utils import Folder
 from data.sync.hello_world_ng import sync_hello_world_ng
 from data.templates import Template
 from products.nativescript.tns import Tns
 
 
-class TnsRunNGTests(TnsTest):
+class TnsRunNGTests(TnsRunTest):
     app_name = Settings.AppName.DEFAULT
     source_project_dir = os.path.join(Settings.TEST_RUN_HOME, app_name)
     target_project_dir = os.path.join(Settings.TEST_RUN_HOME, 'data', 'temp', app_name)
-    emu = None
-    sim = None
 
     @classmethod
     def setUpClass(cls):
-        TnsTest.setUpClass()
-
-        # Boot emulator and simulator
-        cls.emu = DeviceManager.Emulator.ensure_available(Settings.Emulators.DEFAULT)
-        if Settings.HOST_OS == OSType.OSX:
-            cls.sim = DeviceManager.Simulator.ensure_available(Settings.Simulators.DEFAULT)
+        TnsRunTest.setUpClass()
 
         # Create app
         Tns.create(app_name=cls.app_name, template=Template.HELLO_WORLD_NG.local_package, update=True)
@@ -39,9 +30,7 @@ class TnsRunNGTests(TnsTest):
         Folder.copy(source=cls.source_project_dir, target=cls.target_project_dir)
 
     def setUp(self):
-        TnsTest.setUp(self)
-        Adb.open_home(self.emu.id)
-
+        TnsRunTest.setUp(self)
         # "src" folder of TestApp will be restored before each test.
         # This will ensure failures in one test do not cause common failures.
         source_src = os.path.join(self.target_project_dir, 'src')
@@ -49,13 +38,14 @@ class TnsRunNGTests(TnsTest):
         Folder.clean(target_src)
         Folder.copy(source=source_src, target=target_src)
 
-
-class RunAndroidNGTests(TnsRunNGTests):
     def test_100_run_android(self):
         sync_hello_world_ng(self.app_name, Platform.ANDROID, self.emu)
 
     def test_200_run_android_bundle(self):
         sync_hello_world_ng(self.app_name, Platform.ANDROID, self.emu, bundle=True)
+
+    def test_210_run_android_bundle_hmr(self):
+        sync_hello_world_ng(self.app_name, Platform.ANDROID, self.emu, hmr=True)
 
     def test_300_run_android_bundle_aot(self):
         sync_hello_world_ng(self.app_name, Platform.ANDROID, self.emu, bundle=True, aot=True)
@@ -66,20 +56,26 @@ class RunAndroidNGTests(TnsRunNGTests):
     def test_320_run_android_bundle_aot_and_uglify(self):
         sync_hello_world_ng(self.app_name, Platform.ANDROID, self.emu, bundle=True, aot=True, uglify=True)
 
-
-@unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
-class RunIOSNGTests(TnsRunNGTests):
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_100_run_ios(self):
         sync_hello_world_ng(self.app_name, Platform.IOS, self.sim)
 
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_200_run_ios_bundle(self):
         sync_hello_world_ng(self.app_name, Platform.IOS, self.sim, bundle=True)
 
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_210_run_ios_bundle_hmr(self):
+        sync_hello_world_ng(self.app_name, Platform.IOS, self.sim, hmr=True)
+
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_300_run_ios_bundle_aot(self):
         sync_hello_world_ng(self.app_name, Platform.IOS, self.sim, bundle=True, aot=True)
 
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_310_run_ios_bundle_uglify(self):
         sync_hello_world_ng(self.app_name, Platform.IOS, self.sim, bundle=True, uglify=True)
 
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_320_run_ios_bundle_aot_and_uglify(self):
         sync_hello_world_ng(self.app_name, Platform.IOS, self.sim, bundle=True, aot=True, uglify=True)

--- a/tests/cli/run/templates/master_detail_ng_tests.py
+++ b/tests/cli/run/templates/master_detail_ng_tests.py
@@ -1,33 +1,24 @@
 import os
 import unittest
 
-from core.base_test.tns_test import TnsTest
+from core.base_test.tns_run_test import TnsRunTest
 from core.enums.os_type import OSType
 from core.enums.platform_type import Platform
 from core.settings import Settings
-from core.utils.device.adb import Adb
-from core.utils.device.device_manager import DeviceManager
 from core.utils.file_utils import Folder
 from data.sync.master_details_ng import sync_master_detail_ng
 from data.templates import Template
 from products.nativescript.tns import Tns
 
 
-class TnsRunMasterDetailTests(TnsTest):
+class TnsRunMasterDetailTests(TnsRunTest):
     app_name = Settings.AppName.DEFAULT
     source_project_dir = os.path.join(Settings.TEST_RUN_HOME, app_name)
     target_project_dir = os.path.join(Settings.TEST_RUN_HOME, 'data', 'temp', app_name)
-    emu = None
-    sim = None
 
     @classmethod
     def setUpClass(cls):
-        TnsTest.setUpClass()
-
-        # Boot emulator and simulator
-        cls.emu = DeviceManager.Emulator.ensure_available(Settings.Emulators.DEFAULT)
-        if Settings.HOST_OS == OSType.OSX:
-            cls.sim = DeviceManager.Simulator.ensure_available(Settings.Simulators.DEFAULT)
+        TnsRunTest.setUpClass()
 
         # Create app
         Tns.create(app_name=cls.app_name, template=Template.MASTER_DETAIL_NG.local_package, update=True)
@@ -39,9 +30,7 @@ class TnsRunMasterDetailTests(TnsTest):
         Folder.copy(source=cls.source_project_dir, target=cls.target_project_dir)
 
     def setUp(self):
-        TnsTest.setUp(self)
-        Adb.open_home(self.emu.id)
-
+        TnsRunTest.setUp(self)
         # "src" folder of TestApp will be restored before each test.
         # This will ensure failures in one test do not cause common failures.
         source_src = os.path.join(self.target_project_dir, 'src')
@@ -49,8 +38,6 @@ class TnsRunMasterDetailTests(TnsTest):
         Folder.clean(target_src)
         Folder.copy(source=source_src, target=target_src)
 
-
-class RunAndroidMasterDetailNGTests(TnsRunMasterDetailTests):
     def test_100_run_android(self):
         sync_master_detail_ng(self.app_name, Platform.ANDROID, self.emu)
 
@@ -66,20 +53,22 @@ class RunAndroidMasterDetailNGTests(TnsRunMasterDetailTests):
     def test_320_run_android_bundle_aot_and_uglify(self):
         sync_master_detail_ng(self.app_name, Platform.ANDROID, self.emu, bundle=True, aot=True, uglify=True)
 
-
-@unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
-class RunIOSMasterDetailNGTests(TnsRunMasterDetailTests):
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_100_run_ios(self):
         sync_master_detail_ng(self.app_name, Platform.IOS, self.sim)
 
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_200_run_ios_bundle(self):
         sync_master_detail_ng(self.app_name, Platform.IOS, self.sim, bundle=True)
 
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_300_run_ios_bundle_aot(self):
         sync_master_detail_ng(self.app_name, Platform.IOS, self.sim, bundle=True, aot=True)
 
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_310_run_ios_bundle_uglify(self):
         sync_master_detail_ng(self.app_name, Platform.IOS, self.sim, bundle=True, uglify=True)
 
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_320_run_ios_bundle_aot_and_uglify(self):
         sync_master_detail_ng(self.app_name, Platform.IOS, self.sim, bundle=True, aot=True, uglify=True)

--- a/tests/cli/smoke/smoke_tests.py
+++ b/tests/cli/smoke/smoke_tests.py
@@ -1,31 +1,22 @@
 import unittest
 
-from core.base_test.tns_test import TnsTest
+from core.base_test.tns_run_test import TnsRunTest
 from core.enums.os_type import OSType
 from core.enums.platform_type import Platform
 from core.settings import Settings
-from core.utils.device.device_manager import DeviceManager
 from data.sync.hello_world_js import sync_hello_world_js
 from data.sync.hello_world_ng import sync_hello_world_ng
 from data.templates import Template
 from products.nativescript.tns import Tns
 
 
-class SmokeTests(TnsTest):
+class SmokeTests(TnsRunTest):
     js_app = Settings.AppName.DEFAULT + 'JS'
     ng_app = Settings.AppName.DEFAULT + 'NG'
 
-    emu = None
-    sim = None
-
     @classmethod
     def setUpClass(cls):
-        TnsTest.setUpClass()
-
-        # Boot emulator and simulator
-        cls.emu = DeviceManager.Emulator.ensure_available(Settings.Emulators.DEFAULT)
-        if Settings.HOST_OS == OSType.OSX:
-            cls.sim = DeviceManager.Simulator.ensure_available(Settings.Simulators.DEFAULT)
+        TnsRunTest.setUpClass()
 
         # Create JS app and copy to temp data folder
         Tns.create(app_name=cls.js_app, template=Template.HELLO_WORLD_JS.local_package, update=False)


### PR DESCRIPTION
**Base Test Classes**

Introduce new base test classes:
- Base `TnsRunTest` which will start emulator and simulator (only on macOS).
- Base `TnsRunAndroidTest` which will start emulator only.
- Base `TnsRunIOSTest` which will start simulator only.

The idea:
- Remove boilerplate code from setup/teardown of tns tests

**Simctl**

Introduce new methods:
- get list of installed apps
- terminalte all apps
- uninstall all apps

The idea:
- Uninstall all apps before class
- Terminate all apps before each test (to be sure we do not check old screen)