### PR TITLE
fix: get test class name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,4 @@ install:
   - python -m pip install --upgrade pip
   - pip install --upgrade -r requirements.txt
 script:
-  - python -m nose core_tests/unit -v -s --nologcapture --with-doctest --with-xunit
-  - python -m flake8 --max-line-length=120 core core_tests data products tests
-  - python -m pylint --disable=locally-disabled --rcfile=.pylintrc core data products
-  - find core_tests | grep .py | grep -v .pyc | xargs python -m pylint --disable=locally-disabled --rcfile=.pylintrc
-  - find tests | grep .py | grep -v .pyc | xargs python -m pylint --disable=locally-disabled --min-similarity-lines=15 --rcfile=.pylintrc
+  - ./scripts/test.sh

--- a/README.md
+++ b/README.md
@@ -68,25 +68,11 @@ python run_schematics.py tests/code_sharing
 
 Contributions are welcome.
 
-If you wonder how you can contribute, just grab some of the open issues.
+If you wonder how you can contribute, just grab some of the [open issues](https://github.com/NativeScript/nativescript-tooling-qa/issues).
 
-Once you are ready with our changes, please run flake8:
+Once you are ready with our changes, please run:
 ```bash
-python -m flake8 --max-line-length=120 core core_tests data products tests
-```
-
-Notes:
-
-We plan to adopt `pylint`, but we are still in process of defining rules and fixing lint errors.
-```bash
-python -m pylint --disable=locally-disabled --rcfile=.pylintrc core data products
-```
-
-Due to the fact tests are not modules pylint can not be executed directly.
-Workaround:
-```bash
-find core_tests | grep .py | grep -v .pyc | xargs python -m pylint --disable=locally-disabled --rcfile=.pylintrc
-find tests | grep .py | grep -v .pyc | xargs python -m pylint --disable=locally-disabled --min-similarity-lines=15 --rcfile=.pylintrc
+./scripts/test.sh
 ```
 
 ## Hints, Tips and Tricks

--- a/core/base_test/tns_test.py
+++ b/core/base_test/tns_test.py
@@ -21,10 +21,12 @@ class TnsTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # Get class name and log
+        TestContext.CLASS_NAME = cls.__name__
         try:
-            TestContext.CLASS_NAME = inspect.stack()[1][0].f_locals['cls'].__name__
+            for item in inspect.stack():
+                TestContext.CLASS_NAME = item[0].f_locals['cls'].__name__
         except Exception:
-            TestContext.CLASS_NAME = cls.__name__
+            pass
         Log.test_class_start(class_name=TestContext.CLASS_NAME)
 
         # Kill processes

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Run unit tests
+python -m nose core_tests/unit
+
+# Run pylint
+python -m flake8 --max-line-length=120 core core_tests data products tests
+python -m pylint --disable=locally-disabled --rcfile=.pylintrc core data products
+find core_tests | grep .py | grep -v .pyc | xargs python -m pylint --disable=locally-disabled --rcfile=.pylintrc
+find tests | grep .py | grep -v .pyc | xargs python -m pylint --disable=locally-disabled --min-similarity-lines=15 --rcfile=.pylintrc


### PR DESCRIPTION
Fix:
- Get test class name (it was failing when test do not derive TnsTest directly)
```
Logs Before:
TEST CLASS:  TnsRunTest (base class name)
```
```
Logs Now:
TEST CLASS:  <the-real-class-name>
```

Refactor:
- Move all the commands executed on Travis CI in single script so it is easier to run locally
- Refer the script in README.md (and reduce its size)