### PR TITLE
fix: wait for log method not iterating on  some of the strings

### DIFF
--- a/products/nativescript/tns_logs.py
+++ b/products/nativescript/tns_logs.py
@@ -193,12 +193,12 @@ class TnsLogs(object):
             for item in string_list:
                 if item in log:
                     Log.info("'{0}' found.".format(item))
-                    string_list.remove(item)
                 else:
                     not_found_list.append(item)
+            string_list = not_found_list
             if not not_found_list:
                 all_items_found = True
-                Log.info("Log contains: {0}".format(string_list))
+                Log.info("All items found")
                 break
             else:
                 Log.debug("'{0}' NOT found. Wait...".format(not_found_list))


### PR DESCRIPTION
Removing array members dynamically while iterating over 'string_list' in the wait_for_log method causes changes in the array length and members and some strings are missed during the for loop. 

You can see that  in some of the test results: 
```
13:00:59 13:00:58 TAP found on Emulator-Api23-Default.
13:00:59 13:00:58 taps left found on Emulator-Api23-Default.
13:00:59 13:00:58 'Preparing project...' found.
13:00:59 13:00:58 'Successfully transferred main-page.xml' found.
13:00:59 13:00:58 'Successfully synced application org.nativescript.TestApp on device' found.
13:00:59 13:00:58 Log contains: ['Project successfully prepared (Android)', 'Refreshing application on device']
```
On theory  string_list should be empty if we found all the logs but it's not.  

**Fix:**  
Remove the removing of items while in for loop.  After the loop assign string_list = not_found_strings, so we iterate only the items we have not found