### PR TITLE
fix: use app_id in log checks

### DIFF
--- a/products/nativescript/tns_logs.py
+++ b/products/nativescript/tns_logs.py
@@ -100,7 +100,8 @@ class TnsLogs(object):
             logs.extend(TnsLogs.__app_refresh_messages(instrumented=instrumented))
 
         # Add message for successful sync
-        logs.append('Successfully synced application org.nativescript.{0} on device'.format(app_name))
+        app_id = TnsPaths.get_bundle_id(app_name)
+        logs.append('Successfully synced application org.nativescript.{0} on device'.format(app_id))
 
         # Return logs
         return logs
@@ -158,7 +159,7 @@ class TnsLogs(object):
     def __app_restart_messages(app_name, platform, instrumented):
         logs = ['Restarting application on device']
         if platform == Platform.ANDROID:
-            app_id = TnsPaths.get_bundle_if(app_name)
+            app_id = TnsPaths.get_bundle_id(app_name)
             logs.append('ActivityManager: Start proc')
             logs.append('activity org.nativescript.{0}/com.tns.NativeScriptActivity'.format(app_id))
         if instrumented:

--- a/products/nativescript/tns_paths.py
+++ b/products/nativescript/tns_paths.py
@@ -29,5 +29,5 @@ class TnsPaths(object):
         return ''
 
     @staticmethod
-    def get_bundle_if(app_name):
+    def get_bundle_id(app_name):
         return app_name.replace('-', '')


### PR DESCRIPTION
Fix:
- Typo in `TnsPaths.get_bundle_id`
- Use `app_id` instead of `app_name` in successfully synced message:
```
'Successfully synced application org.nativescript.{0} on device'.format(app_id))
```