### PR TITLE
fix: smoke tests

### DIFF
--- a/data/sync/hello_world_js.py
+++ b/data/sync/hello_world_js.py
@@ -67,10 +67,10 @@ def __sync_hello_world_js_ts(app_type, app_name, platform, device,
 
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.FULL, bundle=bundle,
                                    hmr=hmr, instrumented=instrumented)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=240)
 
     # Verify it looks properly
-    device.wait_for_text(text=js_change.old_text, timeout=60, retry_delay=5)
+    device.wait_for_text(text=js_change.old_text)
     device.wait_for_text(text=xml_change.old_text)
     blue_count = device.get_pixels_by_color(color=Colors.LIGHT_BLUE)
     assert blue_count > 100, 'Failed to find blue color on {0}'.format(device.name)

--- a/data/sync/hello_world_js.py
+++ b/data/sync/hello_world_js.py
@@ -24,7 +24,7 @@ def sync_hello_world_js(app_name, platform, device, bundle=False, hmr=False, ugl
 
 
 def sync_hello_world_ts(app_name, platform, device, bundle=False, hmr=False, uglify=False, aot=False,
-                        snapshot=False, instrumented=False):
+                        snapshot=False, instrumented=True):
     __sync_hello_world_js_ts(app_type=AppType.TS, app_name=app_name, platform=platform,
                              device=device,
                              bundle=bundle, hmr=hmr, uglify=uglify, aot=aot, snapshot=snapshot,

--- a/data/sync/hello_world_ng.py
+++ b/data/sync/hello_world_ng.py
@@ -17,11 +17,13 @@ def sync_hello_world_ng(app_name, platform, device, bundle=False, uglify=False, 
                         instrumented=True, app_type=AppType.NG):
     result = Tns.run(app_name=app_name, platform=platform, emulator=True, wait=False,
                      bundle=bundle, aot=aot, uglify=uglify, hmr=hmr)
+    # Check logs
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, bundle=bundle,
                                    hmr=hmr, instrumented=instrumented, app_type=app_type)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=300)
+
     # Verify it looks properly
-    device.wait_for_text(text=Changes.NGHelloWorld.TS.old_text, timeout=300, retry_delay=5)
+    device.wait_for_text(text=Changes.NGHelloWorld.TS.old_text)
     device.wait_for_main_color(color=Colors.WHITE)
     initial_state = os.path.join(Settings.TEST_OUT_IMAGES, device.name, 'initial_state.png')
     device.get_screen(path=initial_state)

--- a/products/nativescript/tns_logs.py
+++ b/products/nativescript/tns_logs.py
@@ -1,4 +1,3 @@
-# pylint: disable=unused-argument
 import time
 
 from core.enums.app_type import AppType
@@ -11,7 +10,6 @@ from products.nativescript.run_type import RunType
 from products.nativescript.tns_paths import TnsPaths
 
 
-# noinspection PyUnusedLocal
 class TnsLogs(object):
     SKIP_NODE_MODULES = ['Skipping node_modules folder!', 'Use the syncAllFiles option to sync files from this folder.']
 
@@ -35,16 +33,13 @@ class TnsLogs(object):
         return logs
 
     @staticmethod
-    def build_messages(platform, run_type=RunType.FULL, plugins=None):
+    def build_messages(platform, run_type=RunType.FULL):
         """
         Get log messages that should be present when project is build.
         :param platform: Platform.ANDROID or Platform.IOS
         :param run_type: RunType enum value.
-        :param plugins: Array of plugins available in the project.
         :return: Array of strings.
         """
-        if plugins is None:
-            plugins = []
         logs = []
         if run_type in [RunType.FIRST_TIME, RunType.FULL]:
             logs = ['Building project...', 'Project successfully built.']
@@ -55,8 +50,8 @@ class TnsLogs(object):
         return logs
 
     @staticmethod
-    def run_messages(app_name, platform, run_type=RunType.FULL, bundle=False, hmr=False, uglify=False, aot=False,
-                     app_type=None, file_name=None, instrumented=False, sync_all_file=False, plugins=None):
+    def run_messages(app_name, platform, run_type=RunType.FULL, bundle=False, hmr=False, uglify=False, app_type=None,
+                     file_name=None, instrumented=False, plugins=None):
         """
         Get log messages that should be present when running a project.
         :param app_name: Name of the app (for example TestApp).
@@ -65,9 +60,9 @@ class TnsLogs(object):
         :param bundle: True if `--bundle is specified.`
         :param hmr: True if `--hmr is specified.`
         :param uglify: True if `--env.uglify is specified.`
+        :param app_type: AppType enum value.
         :param file_name: Name of changed file.
         :param instrumented: If true it will return logs we place inside app (see files in assets/logs).
-        :param sync_all_file: If false will check for logs that syncAllFiles is skipped.
         :param plugins: List of plugins.
         :return: Array of strings.
         """
@@ -95,7 +90,7 @@ class TnsLogs(object):
 
         # File transfer messages
         logs.extend(TnsLogs.__file_changed_messages(run_type=run_type, file_name=file_name, platform=platform,
-                                                    bundle=bundle, hmr=hmr, uglify=uglify, app_type=app_type))
+                                                    bundle=bundle, hmr=hmr, uglify=uglify))
         if run_type in [RunType.FIRST_TIME, RunType.FULL]:
             if not app_type == AppType.NG:
                 if not bundle and not hmr:
@@ -127,7 +122,7 @@ class TnsLogs(object):
         return logs
 
     @staticmethod
-    def __file_changed_messages(run_type, file_name, platform, bundle, hmr, uglify, app_type):
+    def __file_changed_messages(run_type, file_name, platform, bundle, hmr, uglify):
         logs = []
         if file_name is None:
             if run_type not in [RunType.FIRST_TIME, RunType.FULL]:

--- a/tests/cli/regression/test_js_regressions.py
+++ b/tests/cli/regression/test_js_regressions.py
@@ -19,11 +19,11 @@ class JSRegressionTests(TnsRunTest):
         LegacyApp.create(app_name=cls.js_app, app_type=AppType.JS)
 
     def test_100_run_android(self):
-        sync_hello_world_js(app_name=self.js_app, platform=Platform.ANDROID, device=self.emu)
+        sync_hello_world_js(app_name=self.js_app, platform=Platform.ANDROID, device=self.emu, instrumented=False)
 
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_101_run_ios(self):
-        sync_hello_world_js(app_name=self.js_app, platform=Platform.IOS, device=self.sim)
+        sync_hello_world_js(app_name=self.js_app, platform=Platform.IOS, device=self.sim, instrumented=False)
 
     def test_200_build_android_release(self):
         if Settings.HOST_OS != OSType.WINDOWS:

--- a/tests/cli/regression/test_ng_regressions.py
+++ b/tests/cli/regression/test_ng_regressions.py
@@ -33,11 +33,11 @@ class NGRegressionTests(TnsTest):
             Simctl.stop_all(self.sim)
 
     def test_100_run_android(self):
-        sync_hello_world_ng(app_name=self.ng_app, platform=Platform.ANDROID, device=self.emu)
+        sync_hello_world_ng(app_name=self.ng_app, platform=Platform.ANDROID, device=self.emu, instrumented=False)
 
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_101_run_ios(self):
-        sync_hello_world_ng(app_name=self.ng_app, platform=Platform.IOS, device=self.sim)
+        sync_hello_world_ng(app_name=self.ng_app, platform=Platform.IOS, device=self.sim, instrumented=False)
 
     def test_200_build_android_release(self):
         if Settings.HOST_OS != OSType.WINDOWS:

--- a/tests/cli/smoke/smoke_tests.py
+++ b/tests/cli/smoke/smoke_tests.py
@@ -38,8 +38,10 @@ class SmokeTests(TnsRunTest):
         sync_hello_world_js(app_name=self.js_app, platform=Platform.IOS, device=self.sim, instrumented=False)
 
     def test_100_run_android_ng(self):
-        sync_hello_world_ng(app_name=self.ng_app, platform=Platform.ANDROID, device=self.emu, bundle=True)
+        sync_hello_world_ng(app_name=self.ng_app, platform=Platform.ANDROID, device=self.emu, bundle=True,
+                            instrumented=False)
 
     @unittest.skipIf(Settings.HOST_OS is not OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_101_run_ios_ng(self):
-        sync_hello_world_ng(app_name=self.ng_app, platform=Platform.IOS, device=self.sim, bundle=True)
+        sync_hello_world_ng(app_name=self.ng_app, platform=Platform.IOS, device=self.sim, bundle=True,
+                            instrumented=False)


### PR DESCRIPTION
Fix smoke and regression tests by settings `instrumented=False` (we do not instrument those apps).

Other:
- Increase timeouts for tns run (up to 300s for NG and 240 for JS/TS, 180 is not enough on some build machines).
- Fix unused variables in TnsLogs