### PR TITLE
fix: logs in angular tests

### DIFF
--- a/data/sync/hello_world_ng.py
+++ b/data/sync/hello_world_ng.py
@@ -41,7 +41,7 @@ def sync_hello_world_ng(app_name, platform, device, bundle=False, uglify=False, 
     assert not device.is_text_visible(text=Changes.NGHelloWorld.TS.new_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    file_name='items.component.html', hmr=hmr, instrumented=instrumented,
-                                   app_type=app_type)
+                                   app_type=app_type, aot=aot)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
 
     Sync.replace(app_name=app_name, change_set=Changes.NGHelloWorld.CSS)
@@ -58,7 +58,7 @@ def sync_hello_world_ng(app_name, platform, device, bundle=False, uglify=False, 
     device.wait_for_text(text=Changes.NGHelloWorld.TS.new_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    file_name='items.component.html', hmr=hmr, instrumented=instrumented,
-                                   app_type=app_type)
+                                   app_type=app_type, aot=aot)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
 
     Sync.revert(app_name=app_name, change_set=Changes.NGHelloWorld.TS)

--- a/products/nativescript/tns_logs.py
+++ b/products/nativescript/tns_logs.py
@@ -133,7 +133,6 @@ class TnsLogs(object):
         if file_name is None:
             if run_type not in [RunType.FIRST_TIME, RunType.FULL]:
                 logs.append('Skipping prepare.')
-
         else:
             if not hmr:
                 logs.extend(TnsLogs.prepare_messages(platform=platform, plugins=None))


### PR DESCRIPTION
Updated log for specific cases:
When in angular project with hmr changes in app.css file should not cause angular reload. 
When run with env.aot  and change html file it is expected that the file name does not appear as exact string in logs  