### PR TITLE
fix: schematics tests on Windows

### DIFF
--- a/core/base_test/tns_run_test.py
+++ b/core/base_test/tns_run_test.py
@@ -7,6 +7,8 @@ from core.utils.device.simctl import Simctl
 
 
 class TnsRunTest(TnsTest):
+    emu = None
+    sim = None
 
     @classmethod
     def setUpClass(cls):

--- a/core/utils/run.py
+++ b/core/utils/run.py
@@ -4,12 +4,13 @@
 # pylint: disable=unused-variable
 import logging
 import os
-
-import psutil
 import time
 from datetime import datetime
 
+import psutil
+
 from core.base_test.test_context import TestContext
+from core.enums.os_type import OSType
 from core.log.log import Log
 from core.settings import Settings
 from core.utils.file_utils import File, Folder
@@ -50,7 +51,10 @@ def run(cmd, cwd=Settings.TEST_RUN_HOME, wait=True, timeout=600, fail_safe=False
     if wait:
         start = time.time()
         with open(log_file, mode='w') as log:
-            process = subprocess.Popen(cmd, cwd=cwd, shell=True, stdout=subprocess.PIPE, stderr=log)
+            if Settings.HOST_OS == OSType.WINDOWS:
+                process = subprocess.Popen(cmd, cwd=cwd, shell=True, stdout=log, stderr=log)
+            else:
+                process = subprocess.Popen(cmd, cwd=cwd, shell=True, stdout=subprocess.PIPE, stderr=log)
 
         # Wait until command complete
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pylint>=1.9.4
 selenium>=3.141.0
 webdriver_manager>=1.7
 subprocess32>=3.5.3
+requests>=2.21.0

--- a/requirements_darwin.txt
+++ b/requirements_darwin.txt
@@ -16,3 +16,4 @@ webdriver_manager>=1.7
 atomac>=1.1.0
 PyObjC>=5.1.1
 subprocess32>=3.5.3
+requests>=2.21.0

--- a/tests/code_sharing/migrate_web_tests.py
+++ b/tests/code_sharing/migrate_web_tests.py
@@ -4,49 +4,41 @@ import unittest
 
 from parameterized import parameterized
 
-from core.base_test.tns_test import TnsTest
+from core.base_test.tns_run_test import TnsRunTest
 from core.enums.os_type import OSType
 from core.enums.platform_type import Platform
 from core.log.log import Log
 from core.settings import Settings
 from core.utils.chrome import Chrome
-from core.utils.device.adb import Adb
-from core.utils.device.device_manager import DeviceManager
 from products.angular.ng import NG, DEFAULT_WEB_URL
 from products.nativescript.tns import Tns
 
 
 # noinspection PyMethodMayBeStatic
-class MigrateWebToMobileTests(TnsTest):
+class MigrateWebToMobileTests(TnsRunTest):
     app_name = Settings.AppName.DEFAULT
     app_folder = os.path.join(Settings.TEST_RUN_HOME, app_name)
-    emu = None
-    sim = None
     chrome = None
 
     @classmethod
     def setUpClass(cls):
-        TnsTest.setUpClass()
+        TnsRunTest.setUpClass()
         NG.kill()
         NG.new(collection=None, project=cls.app_name)
         cls.chrome = Chrome()
-        cls.emu = DeviceManager.Emulator.ensure_available(Settings.Emulators.DEFAULT)
-        if Settings.HOST_OS is OSType.OSX:
-            cls.sim = DeviceManager.Simulator.ensure_available(Settings.Simulators.DEFAULT)
 
     def setUp(self):
-        TnsTest.setUp(self)
+        TnsRunTest.setUp(self)
         NG.kill()
-        Adb.open_home(device_id=self.emu.id)  # Open home screen just to be sure we do not find text of previous run.
 
     def tearDown(self):
         NG.kill()
-        TnsTest.tearDown(self)
+        TnsRunTest.tearDown(self)
 
     @classmethod
     def tearDownClass(cls):
         cls.chrome.kill()
-        TnsTest.tearDownClass()
+        TnsRunTest.tearDownClass()
 
     def test_01_ng_serve_web(self):
         self.ng_serve(prod=False)

--- a/tests/code_sharing/ng_new_tests.py
+++ b/tests/code_sharing/ng_new_tests.py
@@ -22,15 +22,11 @@ from products.nativescript.tns_paths import TnsPaths
 class NGNewTests(TnsRunTest):
     app_name = Settings.AppName.DEFAULT
     app_path = TnsPaths.get_app_path(app_name=app_name)
-    emulator = None
-    simulator = None
 
     def setUp(self):
         TnsRunTest.setUp(self)
         NG.kill()
         Folder.clean(self.app_path)
-        self.emulator = self.emu
-        self.simulator = self.simulator
 
     def tearDown(self):
         NG.kill()
@@ -98,7 +94,7 @@ class NGNewTests(TnsRunTest):
 
         # Run the app
         NGNewTests.run_bundle(app_data=app_data, webpack=webpack, shared=shared, theme=theme,
-                              emu=NGNewTests.emulator, sim=NGNewTests.simulator)
+                              emu=NGNewTests.emu, sim=NGNewTests.sim)
 
     @staticmethod
     def create_app(app_data, shared, sample, theme, style, prefix, source_dir, webpack):

--- a/tests/code_sharing/ng_new_tests.py
+++ b/tests/code_sharing/ng_new_tests.py
@@ -1,16 +1,12 @@
-# pylint: disable=too-many-branches
-# pylint: disable=too-many-statements
 import os
 import unittest
 
-from core.base_test.tns_test import TnsTest
+from core.base_test.tns_run_test import TnsRunTest
 from core.enums.env import EnvironmentType
 from core.enums.os_type import OSType
 from core.enums.platform_type import Platform
 from core.enums.styling_type import StylingType
 from core.settings import Settings
-from core.utils.device.adb import Adb
-from core.utils.device.device_manager import DeviceManager
 from core.utils.file_utils import Folder
 from core.utils.json_utils import JsonUtils
 from data.apps import Apps
@@ -22,32 +18,20 @@ from products.nativescript.tns_assert import TnsAssert
 
 
 # noinspection PyMethodMayBeStatic
-class NGNewTests(TnsTest):
+class NGNewTests(TnsRunTest):
     app_name = Settings.AppName.DEFAULT
-    app_folder = os.path.join(Settings.TEST_RUN_HOME, app_name)
-    emu = None
-    sim = None
-
-    @classmethod
-    def setUpClass(cls):
-        TnsTest.setUpClass()
-        cls.emu = DeviceManager.Emulator.ensure_available(Settings.Emulators.DEFAULT)
-        if Settings.HOST_OS is OSType.OSX:
-            cls.sim = DeviceManager.Simulator.ensure_available(Settings.Simulators.DEFAULT)
+    emulator = None
+    simulator = None
 
     def setUp(self):
-        TnsTest.setUp(self)
+        TnsRunTest.setUp(self)
         NG.kill()
-        Adb.open_home(device_id=self.emu.id)  # Open home page to be sure we do not find old text
-        Folder.clean(self.app_folder)
+        self.emulator = self.emu
+        self.simulator = self.simulator
 
     def tearDown(self):
         NG.kill()
-        TnsTest.tearDown(self)
-
-    @classmethod
-    def tearDownClass(cls):
-        TnsTest.tearDownClass()
+        TnsRunTest.tearDown(self)
 
     def test_001_simple(self):
         NGNewTests.create_and_run(shared=False)
@@ -110,7 +94,8 @@ class NGNewTests(TnsTest):
             App.update(app_name=NGNewTests.app_name, modules=True, angular=True, typescript=False, web_pack=False)
 
         # Run the app
-        NGNewTests.run_bundle(app_data=app_data, webpack=webpack, shared=shared, theme=theme)
+        NGNewTests.run_bundle(app_data=app_data, webpack=webpack, shared=shared, theme=theme,
+                              emu=NGNewTests.emulator, sim=NGNewTests.simulator)
 
     @staticmethod
     def create_app(app_data, shared, sample, theme, style, prefix, source_dir, webpack):
@@ -163,14 +148,14 @@ class NGNewTests(TnsTest):
             assert Folder.exists(os.path.join(Settings.TEST_RUN_HOME, NGNewTests.app_name, source_dir))
 
     @staticmethod
-    def run_bundle(app_data, webpack, shared, theme):
+    def run_bundle(app_data, webpack, shared, theme, emu, sim):
         # Run android (if webpack is available -> use --bundle)
         Tns.run(app_name=NGNewTests.app_name, platform=Platform.ANDROID, emulator=True, bundle=webpack)
         for text in app_data.texts:
-            NGNewTests.emu.wait_for_text(text=text, timeout=300)
+            emu.wait_for_text(text=text, timeout=300)
             # Check if theme is really applied (only for non shared projects, shared is not good example to check)
             if not shared:
-                blue_pixels = NGNewTests.emu.get_pixels_by_color(color=Colors.LIGHT_BLUE)
+                blue_pixels = emu.get_pixels_by_color(color=Colors.LIGHT_BLUE)
                 if theme:
                     assert blue_pixels > 1000, 'Default {N} theme is NOT applied on Android.'
                 else:
@@ -180,10 +165,10 @@ class NGNewTests(TnsTest):
         if Settings.HOST_OS is OSType.OSX:
             Tns.run(app_name=NGNewTests.app_name, platform=Platform.IOS, emulator=True, bundle=webpack)
             for text in app_data.texts:
-                NGNewTests.sim.wait_for_text(text=text, timeout=300)
+                sim.wait_for_text(text=text, timeout=300)
                 # Check if theme is really applied (only for non shared projects, shared is not good example to check)
                 if not shared:
-                    blue_pixels = NGNewTests.emu.get_pixels_by_color(color=Colors.LIGHT_BLUE)
+                    blue_pixels = emu.get_pixels_by_color(color=Colors.LIGHT_BLUE)
                     if theme:
                         assert blue_pixels > 1000, 'Default {N} theme is NOT applied on iOS.'
                     else:

--- a/tests/code_sharing/ng_new_tests.py
+++ b/tests/code_sharing/ng_new_tests.py
@@ -15,17 +15,20 @@ from products.angular.ng import NG, NS_SCHEMATICS
 from products.nativescript.app import App
 from products.nativescript.tns import Tns
 from products.nativescript.tns_assert import TnsAssert
+from products.nativescript.tns_paths import TnsPaths
 
 
 # noinspection PyMethodMayBeStatic
 class NGNewTests(TnsRunTest):
     app_name = Settings.AppName.DEFAULT
+    app_path = TnsPaths.get_app_path(app_name=app_name)
     emulator = None
     simulator = None
 
     def setUp(self):
         TnsRunTest.setUp(self)
         NG.kill()
+        Folder.clean(self.app_path)
         self.emulator = self.emu
         self.simulator = self.simulator
 


### PR DESCRIPTION
Fix:
- Hang when use `run` method on Windows
- Schematics tests are now ready for linux and windows (and based on TnsRunTest)