### PR TITLE
feat: add vue tests

### DIFF
--- a/data/changes.py
+++ b/data/changes.py
@@ -112,3 +112,14 @@ class Changes(object):
         HTML = ChangeSet(file_path=os.path.join('src', 'app', 'item', 'items.component.html'),
                          old_value='"item.name"', new_value='"item.id"',
                          old_text=None, new_text=None)
+
+    class BlankVue(object):
+        VUE_SCRIPT = ChangeSet(file_path=os.path.join('app', 'components', 'Home.vue'),
+                               old_value='Blank {N}-Vue app', new_value='TEST APP',
+                               old_text='Blank {N}-Vue app', new_text='TEST APP')
+        VUE_TEMPLATE = ChangeSet(file_path=os.path.join('app', 'components', 'Home.vue'),
+                                 old_value='Home', new_value='TITLE',
+                                 old_text='Home', new_text='TITLE')
+        VUE_STYLE = ChangeSet(file_path=os.path.join('app', 'components', 'Home.vue'),
+                              old_value='font-size: 20;', new_value='font-size: 20; color: red;',
+                              old_color=Colors.DARK, new_color=Colors.RED)

--- a/data/sync/blank_vue.py
+++ b/data/sync/blank_vue.py
@@ -9,6 +9,7 @@ from core.settings import Settings
 from core.utils.wait import Wait
 from data.changes import Changes, Sync
 from data.const import Colors
+from products.nativescript.preview_helpers import Preview
 from products.nativescript.run_type import RunType
 from products.nativescript.tns import Tns
 from products.nativescript.tns_logs import TnsLogs
@@ -19,15 +20,15 @@ def __run_vue(app_name, platform, bundle, hmr):
     return Tns.run(app_name=app_name, platform=platform, emulator=True, wait=False, bundle=bundle, hmr=hmr)
 
 
-def __preview_vue(app_name, bundle, hmr):
+def __preview_vue(app_name, platform, device, bundle, hmr):
     # Execute `tns run` and wait until logs are OK
-    return Tns.preview(app_name=app_name, bundle=bundle, hmr=hmr)
+    return Preview.run_app(app_name=app_name, bundle=bundle, hmr=hmr, platform=platform, device=device)
 
 
 def __workflow(preview, app_name, platform, device, bundle=False, hmr=False):
     # Execute tns command
     if preview:
-        result = __preview_vue(app_name=app_name, bundle=bundle, hmr=hmr)
+        result = __preview_vue(app_name=app_name, platform=platform, device=device, bundle=bundle, hmr=hmr)
     else:
         result = __run_vue(app_name=app_name, platform=platform, bundle=bundle, hmr=hmr)
 

--- a/data/sync/blank_vue.py
+++ b/data/sync/blank_vue.py
@@ -4,6 +4,7 @@ Sync changes on JS/TS project helper.
 import os
 
 from core.enums.app_type import AppType
+from core.log.log import Log
 from core.settings import Settings
 from core.utils.wait import Wait
 from data.changes import Changes, Sync
@@ -13,13 +14,29 @@ from products.nativescript.tns import Tns
 from products.nativescript.tns_logs import TnsLogs
 
 
-def sync_blank_vue(app_name, platform, device, bundle=False, hmr=False, instrumented=False):
+def __run_vue(app_name, platform, bundle, hmr):
     # Execute `tns run` and wait until logs are OK
-    result = Tns.run(app_name=app_name, platform=platform, emulator=True, wait=False, bundle=bundle, hmr=hmr)
+    return Tns.run(app_name=app_name, platform=platform, emulator=True, wait=False, bundle=bundle, hmr=hmr)
 
-    strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.FULL, bundle=bundle,
-                                   hmr=hmr, app_type=AppType.VUE, instrumented=instrumented)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=240)
+
+def __preview_vue(app_name, bundle, hmr):
+    # Execute `tns run` and wait until logs are OK
+    return Tns.preview(app_name=app_name, bundle=bundle, hmr=hmr)
+
+
+def __workflow(preview, app_name, platform, device, bundle=False, hmr=False):
+    # Execute tns command
+    if preview:
+        result = __preview_vue(app_name=app_name, bundle=bundle, hmr=hmr)
+    else:
+        result = __run_vue(app_name=app_name, platform=platform, bundle=bundle, hmr=hmr)
+
+    if preview:
+        Log.info('Skip logs checks.')
+    else:
+        strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.FULL, bundle=bundle,
+                                       hmr=hmr, app_type=AppType.VUE)
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=240)
 
     # Verify it looks properly
     device.wait_for_text(text=Changes.BlankVue.VUE_SCRIPT.old_text)
@@ -29,49 +46,78 @@ def sync_blank_vue(app_name, platform, device, bundle=False, hmr=False, instrume
 
     # Edit script in .vue file
     Sync.replace(app_name=app_name, change_set=Changes.BlankVue.VUE_SCRIPT)
-    strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
-                                   hmr=hmr, app_type=AppType.VUE, file_name='Home.vue', instrumented=instrumented)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+    if preview:
+        Log.info('Skip logs checks.')
+    else:
+        strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL,
+                                       bundle=bundle, hmr=hmr, app_type=AppType.VUE, file_name='Home.vue')
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
     device.wait_for_text(text=Changes.BlankVue.VUE_SCRIPT.new_text)
 
     # Edit template in .vue file
     Sync.replace(app_name=app_name, change_set=Changes.BlankVue.VUE_TEMPLATE)
-    strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
-                                   hmr=hmr, app_type=AppType.VUE, file_name='Home.vue', instrumented=instrumented)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+    if preview:
+        Log.info('Skip logs checks.')
+    else:
+        strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL,
+                                       bundle=bundle, hmr=hmr, app_type=AppType.VUE, file_name='Home.vue')
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
     device.wait_for_text(text=Changes.BlankVue.VUE_TEMPLATE.new_text)
 
     # Edit styling in .vue file
     Sync.replace(app_name=app_name, change_set=Changes.BlankVue.VUE_STYLE)
-    strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
-                                   hmr=hmr, app_type=AppType.VUE, file_name='Home.vue', instrumented=instrumented)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+    if preview:
+        Log.info('Skip logs checks.')
+    else:
+        strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL,
+                                       bundle=bundle, hmr=hmr, app_type=AppType.VUE, file_name='Home.vue')
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
     style_applied = Wait.until(lambda: device.get_pixels_by_color(Colors.RED) > 100)
     assert style_applied, 'Failed to sync changes in style.'
 
     # Revert script in .vue file
     Sync.revert(app_name=app_name, change_set=Changes.BlankVue.VUE_SCRIPT)
-    strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
-                                   hmr=hmr, app_type=AppType.VUE, file_name='Home.vue', instrumented=instrumented)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+    if preview:
+        Log.info('Skip logs checks.')
+    else:
+        strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL,
+                                       bundle=bundle, hmr=hmr, app_type=AppType.VUE, file_name='Home.vue')
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
     device.wait_for_text(text=Changes.BlankVue.VUE_SCRIPT.old_text)
 
     # Revert template in .vue file
     Sync.revert(app_name=app_name, change_set=Changes.BlankVue.VUE_TEMPLATE)
-    strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
-                                   hmr=hmr, app_type=AppType.VUE, file_name='Home.vue', instrumented=instrumented)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+    if preview:
+        Log.info('Skip logs checks.')
+    else:
+        strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL,
+                                       bundle=bundle, hmr=hmr, app_type=AppType.VUE, file_name='Home.vue')
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
     device.wait_for_text(text=Changes.BlankVue.VUE_TEMPLATE.old_text)
 
     # Revert styling in .vue file
     Sync.revert(app_name=app_name, change_set=Changes.BlankVue.VUE_STYLE)
-    strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
-                                   hmr=hmr, app_type=AppType.VUE, file_name='Home.vue', instrumented=instrumented)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+    if preview:
+        Log.info('Skip logs checks.')
+    else:
+        strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL,
+                                       bundle=bundle,
+                                       hmr=hmr, app_type=AppType.VUE, file_name='Home.vue')
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
 
-    # Skip next steps because of https://github.com/nativescript-vue/nativescript-vue/issues/425
-    # style_applied = Wait.until(lambda: device.get_pixels_by_color(Colors.RED) == 0)
-    # assert style_applied, 'Failed to sync changes in style.'
+    if hmr:
+        Log.info('Skip next steps because of https://github.com/nativescript-vue/nativescript-vue/issues/425')
+    else:
+        style_applied = Wait.until(lambda: device.get_pixels_by_color(Colors.RED) == 0)
+        assert style_applied, 'Failed to sync changes in style.'
 
     # Assert final and initial states are same
     device.screen_match(expected_image=initial_state, tolerance=1.0, timeout=30)
+
+
+def sync_blank_vue(app_name, platform, device, bundle=False, hmr=False):
+    __workflow(preview=False, app_name=app_name, platform=platform, device=device, bundle=bundle, hmr=hmr)
+
+
+def preview_blank_vue(app_name, platform, device, bundle=False, hmr=False):
+    __workflow(preview=True, app_name=app_name, platform=platform, device=device, bundle=bundle, hmr=hmr)

--- a/data/sync/blank_vue.py
+++ b/data/sync/blank_vue.py
@@ -1,0 +1,77 @@
+"""
+Sync changes on JS/TS project helper.
+"""
+import os
+
+from core.enums.app_type import AppType
+from core.settings import Settings
+from core.utils.wait import Wait
+from data.changes import Changes, Sync
+from data.const import Colors
+from products.nativescript.run_type import RunType
+from products.nativescript.tns import Tns
+from products.nativescript.tns_logs import TnsLogs
+
+
+def sync_blank_vue(app_name, platform, device, bundle=False, hmr=False, instrumented=False):
+    # Execute `tns run` and wait until logs are OK
+    result = Tns.run(app_name=app_name, platform=platform, emulator=True, wait=False, bundle=bundle, hmr=hmr)
+
+    strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.FULL, bundle=bundle,
+                                   hmr=hmr, app_type=AppType.VUE, instrumented=instrumented)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=240)
+
+    # Verify it looks properly
+    device.wait_for_text(text=Changes.BlankVue.VUE_SCRIPT.old_text)
+    device.wait_for_text(text=Changes.BlankVue.VUE_TEMPLATE.old_text)
+    initial_state = os.path.join(Settings.TEST_OUT_IMAGES, device.name, 'initial_state.png')
+    device.get_screen(path=initial_state)
+
+    # Edit script in .vue file
+    Sync.replace(app_name=app_name, change_set=Changes.BlankVue.VUE_SCRIPT)
+    strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
+                                   hmr=hmr, app_type=AppType.VUE, file_name='Home.vue', instrumented=instrumented)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+    device.wait_for_text(text=Changes.BlankVue.VUE_SCRIPT.new_text)
+
+    # Edit template in .vue file
+    Sync.replace(app_name=app_name, change_set=Changes.BlankVue.VUE_TEMPLATE)
+    strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
+                                   hmr=hmr, app_type=AppType.VUE, file_name='Home.vue', instrumented=instrumented)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+    device.wait_for_text(text=Changes.BlankVue.VUE_TEMPLATE.new_text)
+
+    # Edit styling in .vue file
+    Sync.replace(app_name=app_name, change_set=Changes.BlankVue.VUE_STYLE)
+    strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
+                                   hmr=hmr, app_type=AppType.VUE, file_name='Home.vue', instrumented=instrumented)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+    style_applied = Wait.until(lambda: device.get_pixels_by_color(Colors.RED) > 100)
+    assert style_applied, 'Failed to sync changes in style.'
+
+    # Revert script in .vue file
+    Sync.revert(app_name=app_name, change_set=Changes.BlankVue.VUE_SCRIPT)
+    strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
+                                   hmr=hmr, app_type=AppType.VUE, file_name='Home.vue', instrumented=instrumented)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+    device.wait_for_text(text=Changes.BlankVue.VUE_SCRIPT.old_text)
+
+    # Revert template in .vue file
+    Sync.revert(app_name=app_name, change_set=Changes.BlankVue.VUE_TEMPLATE)
+    strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
+                                   hmr=hmr, app_type=AppType.VUE, file_name='Home.vue', instrumented=instrumented)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+    device.wait_for_text(text=Changes.BlankVue.VUE_TEMPLATE.old_text)
+
+    # Revert styling in .vue file
+    Sync.revert(app_name=app_name, change_set=Changes.BlankVue.VUE_STYLE)
+    strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
+                                   hmr=hmr, app_type=AppType.VUE, file_name='Home.vue', instrumented=instrumented)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+
+    # Skip next steps because of https://github.com/nativescript-vue/nativescript-vue/issues/425
+    # style_applied = Wait.until(lambda: device.get_pixels_by_color(Colors.RED) == 0)
+    # assert style_applied, 'Failed to sync changes in style.'
+
+    # Assert final and initial states are same
+    device.screen_match(expected_image=initial_state, tolerance=1.0, timeout=30)

--- a/data/sync/hello_world_js.py
+++ b/data/sync/hello_world_js.py
@@ -10,10 +10,10 @@ from core.utils.file_utils import File
 from core.utils.wait import Wait
 from data.changes import Changes, Sync
 from data.const import Colors
+from products.nativescript.preview_helpers import Preview
 from products.nativescript.run_type import RunType
 from products.nativescript.tns import Tns
 from products.nativescript.tns_logs import TnsLogs
-from products.nativescript.preview_helpers import Preview
 
 
 def sync_hello_world_js(app_name, platform, device, bundle=False, hmr=False, uglify=False, aot=False,
@@ -129,9 +129,8 @@ def __sync_hello_world_js_ts(app_type, app_name, platform, device,
     device.screen_match(expected_image=initial_state, tolerance=1.0, timeout=30)
 
 
-def preview_hello_world_js_ts(app_name, platform, device, bundle=False, hmr=False, uglify=False, aot=False,
-                              instrumented=False):
-    result = Preview.run_app(app_name=app_name, bundle=bundle, hmr=hmr, aot=aot, uglify=uglify, platform=platform,
+def preview_hello_world_js_ts(app_name, platform, device, bundle=False, hmr=False, instrumented=False):
+    result = Preview.run_app(app_name=app_name, bundle=bundle, hmr=hmr, platform=platform,
                              device=device, instrumented=instrumented)
 
     # Verify app looks properly
@@ -143,10 +142,9 @@ def preview_hello_world_js_ts(app_name, platform, device, bundle=False, hmr=Fals
     return result
 
 
-def preview_sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=False, hmr=False, uglify=False,
-                                   aot=False, instrumented=False):
+def preview_sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=False, hmr=False, instrumented=False):
     result = preview_hello_world_js_ts(app_name=app_name, platform=platform, device=device, bundle=bundle, hmr=hmr,
-                                       uglify=uglify, aot=aot, instrumented=instrumented)
+                                       instrumented=instrumented)
 
     blue_count = device.get_pixels_by_color(color=Colors.LIGHT_BLUE)
     # Set changes

--- a/data/sync/hello_world_ng.py
+++ b/data/sync/hello_world_ng.py
@@ -20,7 +20,7 @@ def sync_hello_world_ng(app_name, platform, device, bundle=False, uglify=False, 
     result = Tns.run(app_name=app_name, platform=platform, emulator=True, wait=False,
                      bundle=bundle, aot=aot, uglify=uglify, hmr=hmr)
     # Check logs
-    strings = TnsLogs.run_messages(app_name=app_name, platform=platform, bundle=bundle,
+    strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.UNKNOWN, bundle=bundle,
                                    hmr=hmr, instrumented=instrumented, app_type=AppType.NG)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=300)
 

--- a/data/sync/hello_world_ng.py
+++ b/data/sync/hello_world_ng.py
@@ -89,9 +89,8 @@ def sync_hello_world_ng(app_name, platform, device, bundle=False, uglify=False, 
     device.screen_match(expected_image=initial_state, tolerance=1.0, timeout=30)
 
 
-def preview_hello_world_ng(app_name, platform, device, bundle=False, hmr=False, uglify=False, aot=False,
-                           instrumented=False):
-    result = Preview.run_app(app_name=app_name, bundle=bundle, hmr=hmr, aot=aot, uglify=uglify, platform=platform,
+def preview_hello_world_ng(app_name, platform, device, bundle=False, hmr=False, instrumented=False):
+    result = Preview.run_app(app_name=app_name, bundle=bundle, hmr=hmr, platform=platform,
                              device=device, instrumented=instrumented)
 
     # Verify app looks properly
@@ -102,10 +101,9 @@ def preview_hello_world_ng(app_name, platform, device, bundle=False, hmr=False, 
     return result
 
 
-def preview_sync_hello_world_ng(app_name, platform, device, bundle=False, hmr=False, uglify=False,
-                                aot=False, instrumented=False):
+def preview_sync_hello_world_ng(app_name, platform, device, bundle=False, hmr=False, instrumented=False):
     result = preview_hello_world_ng(app_name=app_name, platform=platform, device=device, bundle=bundle, hmr=hmr,
-                                    uglify=uglify, aot=aot, instrumented=instrumented)
+                                    instrumented=instrumented)
 
     # Edit TS file and verify changes are applied
     Sync.replace(app_name=app_name, change_set=Changes.NGHelloWorld.TS)

--- a/data/sync/hello_world_ng.py
+++ b/data/sync/hello_world_ng.py
@@ -3,24 +3,25 @@ Sync changes on NG project helper.
 """
 
 import os
+
 from core.enums.app_type import AppType
 from core.enums.platform_type import Platform
 from core.settings import Settings
 from data.changes import Changes, Sync
 from data.const import Colors
+from products.nativescript.preview_helpers import Preview
 from products.nativescript.run_type import RunType
 from products.nativescript.tns import Tns
 from products.nativescript.tns_logs import TnsLogs
-from products.nativescript.preview_helpers import Preview
 
 
 def sync_hello_world_ng(app_name, platform, device, bundle=False, uglify=False, aot=False, hmr=False,
-                        instrumented=True, app_type=AppType.NG):
+                        instrumented=True):
     result = Tns.run(app_name=app_name, platform=platform, emulator=True, wait=False,
                      bundle=bundle, aot=aot, uglify=uglify, hmr=hmr)
     # Check logs
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, bundle=bundle,
-                                   hmr=hmr, instrumented=instrumented, app_type=app_type)
+                                   hmr=hmr, instrumented=instrumented, app_type=AppType.NG)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=300)
 
     # Verify it looks properly
@@ -33,7 +34,7 @@ def sync_hello_world_ng(app_name, platform, device, bundle=False, uglify=False, 
     Sync.replace(app_name=app_name, change_set=Changes.NGHelloWorld.TS)
     device.wait_for_text(text=Changes.NGHelloWorld.TS.new_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
-                                   file_name='item.service.ts', hmr=hmr, instrumented=instrumented, app_type=app_type)
+                                   file_name='item.service.ts', hmr=hmr, instrumented=instrumented, app_type=AppType.NG)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
 
     Sync.replace(app_name=app_name, change_set=Changes.NGHelloWorld.HTML)
@@ -46,7 +47,7 @@ def sync_hello_world_ng(app_name, platform, device, bundle=False, uglify=False, 
     assert not device.is_text_visible(text=Changes.NGHelloWorld.TS.new_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    file_name='items.component.html', hmr=hmr, instrumented=instrumented,
-                                   app_type=app_type, aot=aot)
+                                   app_type=AppType.NG, aot=aot)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
 
     Sync.replace(app_name=app_name, change_set=Changes.NGHelloWorld.CSS)
@@ -59,7 +60,7 @@ def sync_hello_world_ng(app_name, platform, device, bundle=False, uglify=False, 
             device.wait_for_text(text=number)
     assert not device.is_text_visible(text=Changes.NGHelloWorld.TS.new_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
-                                   file_name='app.css', hmr=hmr, instrumented=instrumented, app_type=app_type)
+                                   file_name='app.css', hmr=hmr, instrumented=instrumented, app_type=AppType.NG)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
 
     # Revert changes
@@ -67,21 +68,21 @@ def sync_hello_world_ng(app_name, platform, device, bundle=False, uglify=False, 
     device.wait_for_text(text=Changes.NGHelloWorld.TS.new_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    file_name='items.component.html', hmr=hmr, instrumented=instrumented,
-                                   app_type=app_type, aot=aot)
+                                   app_type=AppType.NG, aot=aot)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
 
     Sync.revert(app_name=app_name, change_set=Changes.NGHelloWorld.TS)
     device.wait_for_text(text=Changes.NGHelloWorld.TS.old_text)
     device.wait_for_main_color(color=Colors.DARK)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
-                                   file_name='item.service.ts', hmr=hmr, instrumented=instrumented, app_type=app_type)
+                                   file_name='item.service.ts', hmr=hmr, instrumented=instrumented, app_type=AppType.NG)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
 
     Sync.revert(app_name=app_name, change_set=Changes.NGHelloWorld.CSS)
     device.wait_for_main_color(color=Colors.WHITE)
     device.wait_for_text(text=Changes.NGHelloWorld.TS.old_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
-                                   file_name='app.css', hmr=hmr, instrumented=instrumented, app_type=app_type)
+                                   file_name='app.css', hmr=hmr, instrumented=instrumented, app_type=AppType.NG)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
 
     # Assert final and initial states are same

--- a/products/nativescript/preview_helpers.py
+++ b/products/nativescript/preview_helpers.py
@@ -1,6 +1,7 @@
 import os
 import re
 import time
+
 from core.enums.platform_type import Platform
 from core.settings import Settings
 from core.settings.Settings import TEST_SUT_HOME, TEST_RUN_HOME
@@ -97,9 +98,8 @@ class Preview(object):
         run(command)
 
     @staticmethod
-    def run_app(app_name, platform, device, bundle=False, hmr=False, uglify=False, aot=False,
-                instrumented=False):
-        result = Tns.preview(app_name=app_name, bundle=bundle, hmr=hmr, aot=aot, uglify=uglify)
+    def run_app(app_name, platform, device, bundle=False, hmr=False, instrumented=False):
+        result = Tns.preview(app_name=app_name, bundle=bundle, hmr=hmr)
 
         # Read the log and extract the url to load the app on emulator
         log = File.read(result.log_file)

--- a/products/nativescript/preview_helpers.py
+++ b/products/nativescript/preview_helpers.py
@@ -115,8 +115,8 @@ class Preview(object):
         log = File.read(result.log_file)
         url = Preview.get_url(log)
         Preview.run_url(url=url, device=device)
-        # When you run preview on ios simulator on first run confirmation dialog is showh. This script will dismiss it
-        if platform == Platform.IOS:
+        # When you run preview on ios simulator on first run confirmation dialog is shown.
+        if device.type == DeviceType.SIM:
             time.sleep(2)
             Preview.dismiss_simulator_alert()
 

--- a/products/nativescript/run_type.py
+++ b/products/nativescript/run_type.py
@@ -11,6 +11,7 @@ class RunType(IntEnum):
     INCREMENTAL = 2, 'incremental'  # Some js/xml/css file is changed and incremental prepare is triggered.
     FULL = 3, 'full'  # Full prepare. Rebuild native frameworks.
     FIRST_TIME = 4, 'full (no platforms)'  # When platforms are not added to project prepare should add them.
+    UNKNOWN = 9, 'unknown'  # When you are not sure what is the run type.
 
     def __str__(self):
         return self.string

--- a/products/nativescript/tns.py
+++ b/products/nativescript/tns.py
@@ -300,6 +300,26 @@ class Tns(object):
         return result
 
     @staticmethod
+    def preview(app_name, bundle=False, hmr=False, log_trace=True, verify=True, timeout=120):
+        """
+        Execute `tns preview` command.
+        :param app_name: Pass --path <app_name>.
+        :param bundle: If true pass --bundle.
+        :param hmr: If true pass --hmr.
+        :param log_trace: If true pass --log trace.
+        :param verify: If true verify some logs.
+        :param timeout: Timeout in seconds.
+        :return: Result of `tns preview` command.
+        """
+        result = Tns.exec_command(command='preview', path=app_name, bundle=bundle, hmr=hmr, wait=False,
+                                  log_trace=log_trace, timeout=timeout)
+        if verify:
+            strings = [
+                'Use NativeScript Playground app and scan the QR code above to preview the application on your device']
+            TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+        return result
+
+    @staticmethod
     def test_init(app_name, framework, verify=True):
         """
         Execute `tns test init` command.
@@ -381,15 +401,3 @@ class Tns(object):
         else:
             Process.kill(proc_name='node', proc_cmdline=Settings.Executables.TNS)
             Process.kill_by_commandline(cmdline='webpack.js')
-
-    @staticmethod
-    def preview(app_name, bundle=False, hmr=False, aot=False, uglify=False, wait=False,
-                log_trace=True, verify=True, timeout=60):
-        result = Tns.exec_command(command='preview', path=app_name, bundle=bundle, hmr=hmr, aot=aot, uglify=uglify,
-                                  wait=wait, log_trace=log_trace, timeout=timeout)
-        if verify:
-            strings = [
-                'Use NativeScript Playground app and scan the QR code above to preview the application on your device']
-            TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-
-        return result

--- a/products/nativescript/tns_logs.py
+++ b/products/nativescript/tns_logs.py
@@ -91,12 +91,15 @@ class TnsLogs(object):
                                                     bundle=bundle, hmr=hmr, uglify=uglify, aot=aot, app_type=app_type))
 
         # App restart messages:
-        if TnsLogs.__should_restart(run_type=run_type, bundle=bundle, hmr=hmr, file_name=file_name):
-            logs.extend(TnsLogs.__app_restart_messages(app_name=app_name, platform=platform,
-                                                       instrumented=instrumented, app_type=app_type))
+        if RunType.UNKNOWN:
+            Log.info('Can not define if app should be restarted or not.')
         else:
-            logs.extend(TnsLogs.__app_refresh_messages(instrumented=instrumented, app_type=app_type,
-                                                       file_name=file_name, hmr=hmr))
+            if TnsLogs.__should_restart(run_type=run_type, bundle=bundle, hmr=hmr, file_name=file_name):
+                logs.extend(TnsLogs.__app_restart_messages(app_name=app_name, platform=platform,
+                                                           instrumented=instrumented, app_type=app_type))
+            else:
+                logs.extend(TnsLogs.__app_refresh_messages(instrumented=instrumented, app_type=app_type,
+                                                           file_name=file_name, hmr=hmr))
 
         # Add message for successful sync
         app_id = TnsPaths.get_bundle_id(app_name)

--- a/products/nativescript/tns_logs.py
+++ b/products/nativescript/tns_logs.py
@@ -91,7 +91,7 @@ class TnsLogs(object):
                                                     bundle=bundle, hmr=hmr, uglify=uglify, aot=aot, app_type=app_type))
 
         # App restart messages:
-        if RunType.UNKNOWN:
+        if run_type == RunType.UNKNOWN:
             Log.info('Can not define if app should be restarted or not.')
         else:
             if TnsLogs.__should_restart(run_type=run_type, bundle=bundle, hmr=hmr, file_name=file_name):

--- a/products/nativescript/tns_logs.py
+++ b/products/nativescript/tns_logs.py
@@ -56,7 +56,7 @@ class TnsLogs(object):
         Get log messages that should be present when running a project.
         :param app_name: Name of the app (for example TestApp).
         :param platform: Platform.ANDROID or Platform.IOS.
-        :param run_type: RunType enum value.
+        :param run_type: RunType enum value (None when it can not be defined strictly).
         :param bundle: True if `--bundle is specified.`
         :param hmr: True if `--hmr is specified.`
         :param uglify: True if `--env.uglify is specified.`
@@ -118,7 +118,7 @@ class TnsLogs(object):
     def __file_changed_messages(run_type, file_name, platform, bundle, hmr, uglify, aot=False, app_type=None):
         logs = []
         if file_name is None:
-            if run_type not in [RunType.FIRST_TIME, RunType.FULL]:
+            if run_type not in [RunType.FIRST_TIME, RunType.FULL, RunType.UNKNOWN]:
                 logs.append('Skipping prepare.')
         else:
             if not hmr:

--- a/products/nativescript/tns_logs.py
+++ b/products/nativescript/tns_logs.py
@@ -88,17 +88,7 @@ class TnsLogs(object):
 
         # File transfer messages
         logs.extend(TnsLogs.__file_changed_messages(run_type=run_type, file_name=file_name, platform=platform,
-                                                    bundle=bundle, hmr=hmr, uglify=uglify, aot=aot))
-        if run_type in [RunType.FIRST_TIME, RunType.FULL]:
-            if not bundle and not hmr:
-                if platform == Platform.IOS:
-                    logs.append('Successfully transferred all files on device')
-            if bundle or hmr:
-                if platform == Platform.IOS:
-                    logs.append('Successfully transferred bundle.js on device')
-                    logs.append('Successfully transferred package.json on device')
-                    logs.append('Successfully transferred starter.js on device')
-                    logs.append('Successfully transferred vendor.js on device')
+                                                    bundle=bundle, hmr=hmr, uglify=uglify, aot=aot, app_type=app_type))
 
         # App restart messages:
         if TnsLogs.__should_restart(run_type=run_type, bundle=bundle, hmr=hmr, file_name=file_name):
@@ -125,7 +115,7 @@ class TnsLogs(object):
         return logs
 
     @staticmethod
-    def __file_changed_messages(run_type, file_name, platform, bundle, hmr, uglify, aot=False):
+    def __file_changed_messages(run_type, file_name, platform, bundle, hmr, uglify, aot=False, app_type=None):
         logs = []
         if file_name is None:
             if run_type not in [RunType.FIRST_TIME, RunType.FULL]:
@@ -160,6 +150,18 @@ class TnsLogs(object):
             else:
                 # If bundle is not used then TS files are transpiled and synced as JS
                 logs.append('Successfully transferred {0}'.format(file_name.replace('.ts', '.js')))
+
+        # Migrated
+        if run_type in [RunType.FIRST_TIME, RunType.FULL]:
+            if platform == Platform.IOS:
+                if (bundle or hmr) and app_type != AppType.VUE:
+                    logs.append('Successfully transferred bundle.js on device')
+                    logs.append('Successfully transferred package.json on device')
+                    logs.append('Successfully transferred starter.js on device')
+                    logs.append('Successfully transferred vendor.js on device')
+                else:
+                    logs.append('Successfully transferred all files on device')
+
         return logs
 
     @staticmethod

--- a/run_common.py
+++ b/run_common.py
@@ -44,7 +44,8 @@ def __get_templates():
     local_folder = os.path.join(Settings.TEST_SUT_HOME, 'templates')
     Git.clone(repo_url=Template.REPO, branch=branch, local_folder=local_folder)
 
-    apps = [Template.HELLO_WORLD_JS, Template.HELLO_WORLD_TS, Template.HELLO_WORLD_NG, Template.MASTER_DETAIL_NG]
+    apps = [Template.HELLO_WORLD_JS, Template.HELLO_WORLD_TS, Template.HELLO_WORLD_NG, Template.MASTER_DETAIL_NG,
+            Template.VUE_BLANK]
     for app in apps:
         template_name = app.name
         template_folder = os.path.join(local_folder, 'packages', template_name)

--- a/run_preview.py
+++ b/run_preview.py
@@ -6,7 +6,7 @@ import run_common
 from core.log.log import Log
 
 if __name__ == '__main__':
-    run_common.prepare(clone_templates=False, install_ng_cli=False, get_preivew_packages=True)
+    run_common.prepare(clone_templates=True, install_ng_cli=False, get_preivew_packages=True)
     Log.info("Running tests...")
     arguments = ['nosetests', '-v', '-s', '--nologcapture', '--logging-filter=nose', '--with-xunit', '--with-flaky']
     for i in sys.argv:

--- a/tests/vue/test_vue_preview.py
+++ b/tests/vue/test_vue_preview.py
@@ -1,0 +1,58 @@
+import os
+import unittest
+
+from core.base_test.tns_run_test import TnsRunTest
+from core.enums.os_type import OSType
+from core.enums.platform_type import Platform
+from core.settings import Settings
+from core.utils.file_utils import Folder
+from data.sync.blank_vue import preview_blank_vue
+from data.templates import Template
+from products.nativescript.preview_helpers import Preview
+from products.nativescript.tns import Tns
+
+
+class VueJSPreviewTests(TnsRunTest):
+    app_name = Settings.AppName.DEFAULT
+    source_project_dir = os.path.join(Settings.TEST_RUN_HOME, app_name)
+    target_project_dir = os.path.join(Settings.TEST_RUN_HOME, 'data', 'temp', app_name)
+
+    @classmethod
+    def setUpClass(cls):
+        TnsRunTest.setUpClass()
+        Preview.install_preview_app(cls.emu, Platform.ANDROID)
+        if Settings.HOST_OS is OSType.OSX:
+            Preview.install_preview_app(cls.sim, Platform.IOS)
+            Preview.install_playground_app(cls.sim, Platform.IOS)
+
+        # Create app
+        Tns.create(app_name=cls.app_name, template=Template.VUE_BLANK.local_package, update=True)
+        Tns.platform_add_android(app_name=cls.app_name, framework_path=Settings.Android.FRAMEWORK_PATH)
+        if Settings.HOST_OS is OSType.OSX:
+            Tns.platform_add_ios(app_name=cls.app_name, framework_path=Settings.IOS.FRAMEWORK_PATH)
+
+        # Copy TestApp to data folder.
+        Folder.copy(source=cls.source_project_dir, target=cls.target_project_dir)
+
+    def setUp(self):
+        TnsRunTest.setUp(self)
+        # "src" folder of TestApp will be restored before each test.
+        # This will ensure failures in one test do not cause common failures.
+        source_src = os.path.join(self.target_project_dir, 'app')
+        target_src = os.path.join(self.source_project_dir, 'app')
+        Folder.clean(target_src)
+        Folder.copy(source=source_src, target=target_src)
+
+    def test_100_preview_android_bundle(self):
+        preview_blank_vue(self.app_name, Platform.ANDROID, self.emu, bundle=True)
+
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_100_preview_ios_bundle(self):
+        preview_blank_vue(self.app_name, Platform.IOS, self.sim, bundle=True)
+
+    def test_200_preview_android_bundle_hmr(self):
+        preview_blank_vue(self.app_name, Platform.ANDROID, self.emu, hmr=True)
+
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_200_preview_ios_bundle_hmr(self):
+        preview_blank_vue(self.app_name, Platform.IOS, self.sim, hmr=True)

--- a/tests/vue/test_vue_run.py
+++ b/tests/vue/test_vue_run.py
@@ -1,0 +1,53 @@
+import os
+import unittest
+
+from core.base_test.tns_run_test import TnsRunTest
+from core.enums.os_type import OSType
+from core.enums.platform_type import Platform
+from core.settings import Settings
+from core.utils.file_utils import Folder
+from data.sync.blank_vue import sync_blank_vue
+from data.templates import Template
+from products.nativescript.tns import Tns
+
+
+class VueJSTests(TnsRunTest):
+    app_name = Settings.AppName.DEFAULT
+    source_project_dir = os.path.join(Settings.TEST_RUN_HOME, app_name)
+    target_project_dir = os.path.join(Settings.TEST_RUN_HOME, 'data', 'temp', app_name)
+
+    @classmethod
+    def setUpClass(cls):
+        TnsRunTest.setUpClass()
+
+        # Create app
+        Tns.create(app_name=cls.app_name, template=Template.VUE_BLANK.local_package, update=True)
+        Tns.platform_add_android(app_name=cls.app_name, framework_path=Settings.Android.FRAMEWORK_PATH)
+        if Settings.HOST_OS is OSType.OSX:
+            Tns.platform_add_ios(app_name=cls.app_name, framework_path=Settings.IOS.FRAMEWORK_PATH)
+
+        # Copy TestApp to data folder.
+        Folder.copy(source=cls.source_project_dir, target=cls.target_project_dir)
+
+    def setUp(self):
+        TnsRunTest.setUp(self)
+        # "src" folder of TestApp will be restored before each test.
+        # This will ensure failures in one test do not cause common failures.
+        source_src = os.path.join(self.target_project_dir, 'app')
+        target_src = os.path.join(self.source_project_dir, 'app')
+        Folder.clean(target_src)
+        Folder.copy(source=source_src, target=target_src)
+
+    def test_100_run_android_bundle(self):
+        sync_blank_vue(self.app_name, Platform.ANDROID, self.emu, bundle=True)
+
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_100_run_ios_bundle(self):
+        sync_blank_vue(self.app_name, Platform.IOS, self.sim, bundle=True)
+
+    def test_200_run_android_bundle_hmr(self):
+        sync_blank_vue(self.app_name, Platform.ANDROID, self.emu, hmr=True)
+
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_200_run_ios_bundle_hmr(self):
+        sync_blank_vue(self.app_name, Platform.IOS, self.sim, hmr=True)


### PR DESCRIPTION
New:
- Livesync tests for vue blank template

Refactor:
- Remove `app_type=AppType.NG` param from `sync_hello_world_ng` (it obviously can't be different than NG)
- Remove some `if not app_type == AppType.NG:` checks from TnsLogs (I don't see why we need them)
- Do not check of file name in logs in `__file_changed_messages()` when change is in `*.vue` file
- Pack Template.VUE_BLANK before tests