### PR TITLE
refactor: optimize build times

### DIFF
--- a/core/utils/file_utils.py
+++ b/core/utils/file_utils.py
@@ -141,9 +141,9 @@ class File(object):
         return os.path.isfile(path)
 
     @staticmethod
-    def copy(src, target):
-        shutil.copy(src, target)
-        Log.info('Copy {0} to {1}'.format(os.path.abspath(src), os.path.abspath(target)))
+    def copy(source, target):
+        shutil.copy(source, target)
+        Log.info('Copy {0} to {1}'.format(os.path.abspath(source), os.path.abspath(target)))
 
     @staticmethod
     def delete(path):

--- a/core/utils/npm.py
+++ b/core/utils/npm.py
@@ -37,14 +37,14 @@ class Npm(object):
         src_file = os.path.join(Settings.TEST_SUT_HOME, npm_package)
         File.delete(path=output_file)
         Npm.__run_npm_command('pack ' + output, folder=Settings.TEST_SUT_HOME)
-        File.copy(src=src_file, target=output_file)
+        File.copy(source=src_file, target=output_file)
         File.delete(src_file)
 
     @staticmethod
     def pack(folder, output_file):
         Npm.__run_npm_command('pack', folder=folder)
         src_file = File.find_by_extension(folder=folder, extension='tgz')[0]
-        File.copy(src=src_file, target=output_file)
+        File.copy(source=src_file, target=output_file)
         File.delete(src_file)
 
     @staticmethod

--- a/core_tests/unit/utils/file_tests.py
+++ b/core_tests/unit/utils/file_tests.py
@@ -20,7 +20,7 @@ class FileUtilsTests(unittest.TestCase):
         new_value = 'Android here\n.page { background-color: red;}'
 
         # Create new file (so we don't break original one).
-        File.copy(src=old_scss, target=new_scss)
+        File.copy(source=old_scss, target=new_scss)
         assert len(File.read(path=new_scss).splitlines()) == 14, 'Unexpected lines count.'
 
         # Replace

--- a/data/sync/hello_world_js.py
+++ b/data/sync/hello_world_js.py
@@ -66,7 +66,7 @@ def __sync_hello_world_js_ts(app_type, app_name, platform, device,
                      bundle=bundle, hmr=hmr, uglify=uglify, aot=aot, snapshot=snapshot)
     __verify_snapshot_skipped(snapshot, result)
 
-    strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.FULL, bundle=bundle,
+    strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.UNKNOWN, bundle=bundle,
                                    hmr=hmr, instrumented=instrumented)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=240)
 

--- a/products/nativescript/preview_helpers.py
+++ b/products/nativescript/preview_helpers.py
@@ -20,10 +20,10 @@ class Preview(object):
     @staticmethod
     def get_app_packages():
         """Copy Preview App packages from Shares to local folder"""
-        File.copy(src=Settings.Packages.PREVIEW_APP_IOS, target=TEST_SUT_HOME)
-        File.copy(src=Settings.Packages.PREVIEW_APP_ANDROID, target=TEST_SUT_HOME)
-        File.copy(src=Settings.Packages.PLAYGROUND_APP_IOS, target=TEST_SUT_HOME)
-        File.copy(src=Settings.Packages.PLAYGROUND_APP_ANDROID, target=TEST_SUT_HOME)
+        File.copy(source=Settings.Packages.PREVIEW_APP_IOS, target=TEST_SUT_HOME)
+        File.copy(source=Settings.Packages.PREVIEW_APP_ANDROID, target=TEST_SUT_HOME)
+        File.copy(source=Settings.Packages.PLAYGROUND_APP_IOS, target=TEST_SUT_HOME)
+        File.copy(source=Settings.Packages.PLAYGROUND_APP_ANDROID, target=TEST_SUT_HOME)
 
     @staticmethod
     def unpack_ios_simulator_packages():

--- a/run_common.py
+++ b/run_common.py
@@ -72,7 +72,7 @@ def __get_runtimes():
     # Copy or download tns-android
     android_package = os.path.join(Settings.TEST_SUT_HOME, 'tns-android.tgz')
     if '.tgz' in Settings.Packages.ANDROID:
-        File.copy(src=Settings.Packages.ANDROID, target=android_package)
+        File.copy(source=Settings.Packages.ANDROID, target=android_package)
         Settings.Packages.ANDROID = android_package
     else:
         Npm.download(package=Settings.Packages.ANDROID, output_file=android_package)
@@ -81,7 +81,7 @@ def __get_runtimes():
     if Settings.HOST_OS == OSType.OSX:
         ios_package = os.path.join(Settings.TEST_SUT_HOME, 'tns-ios.tgz')
         if '.tgz' in Settings.Packages.IOS:
-            File.copy(src=Settings.Packages.IOS, target=ios_package)
+            File.copy(source=Settings.Packages.IOS, target=ios_package)
             Settings.Packages.IOS = ios_package
         else:
             Npm.download(package=Settings.Packages.IOS, output_file=ios_package)
@@ -95,7 +95,7 @@ def __install_ns_cli():
     # Copy NativeScript CLI (if used from local package)
     if '.tgz' in Settings.Packages.NS_CLI:
         cli_package = os.path.join(Settings.TEST_SUT_HOME, 'nativescript.tgz')
-        File.copy(src=Settings.Packages.NS_CLI, target=cli_package)
+        File.copy(source=Settings.Packages.NS_CLI, target=cli_package)
         Settings.Packages.NS_CLI = cli_package
 
     # Install NativeScript CLI

--- a/tests/cli/preview/templates/hello_word_js_tests.py
+++ b/tests/cli/preview/templates/hello_word_js_tests.py
@@ -35,7 +35,7 @@ class TnsPreviewJSTests(TnsRunTest):
         Tns.create(app_name=cls.app_name, template=Template.HELLO_WORLD_JS.local_package, update=True)
         src = os.path.join(Settings.TEST_RUN_HOME, 'assets', 'logs', 'hello-world-js', 'app.js')
         target = os.path.join(Settings.TEST_RUN_HOME, cls.app_name, 'app')
-        File.copy(src=src, target=target)
+        File.copy(source=src, target=target)
 
         # Copy TestApp to data folder.
         Folder.copy(source=cls.source_project_dir, target=cls.target_project_dir)

--- a/tests/cli/preview/templates/hello_word_ng_tests.py
+++ b/tests/cli/preview/templates/hello_word_ng_tests.py
@@ -34,10 +34,10 @@ class TnsPreviewNGTests(TnsRunTest):
         Tns.create(app_name=cls.app_name, template=Template.HELLO_WORLD_NG.local_package, update=True)
         src = os.path.join(Settings.TEST_RUN_HOME, 'assets', 'logs', 'hello-world-ng', 'main.ts')
         target = os.path.join(Settings.TEST_RUN_HOME, cls.app_name, 'src')
-        File.copy(src=src, target=target)
+        File.copy(source=src, target=target)
         src = os.path.join(Settings.TEST_RUN_HOME, 'assets', 'logs', 'hello-world-ng', 'items.component.ts')
         target = os.path.join(Settings.TEST_RUN_HOME, cls.app_name, 'src', 'app', 'item')
-        File.copy(src=src, target=target)
+        File.copy(source=src, target=target)
 
         # Copy TestApp to data folder.
         Folder.copy(source=cls.source_project_dir, target=cls.target_project_dir)

--- a/tests/cli/run/templates/hello_world_js_tests.py
+++ b/tests/cli/run/templates/hello_world_js_tests.py
@@ -6,6 +6,7 @@ from core.enums.os_type import OSType
 from core.enums.platform_type import Platform
 from core.settings import Settings
 from core.utils.file_utils import Folder, File
+from data.changes import Changes
 from data.sync.hello_world_js import sync_hello_world_js
 from data.templates import Template
 from products.nativescript.tns import Tns
@@ -24,7 +25,7 @@ class TnsRunJSTests(TnsRunTest):
         Tns.create(app_name=cls.app_name, template=Template.HELLO_WORLD_JS.local_package, update=True)
         src = os.path.join(Settings.TEST_RUN_HOME, 'assets', 'logs', 'hello-world-js', 'app.js')
         target = os.path.join(Settings.TEST_RUN_HOME, cls.app_name, 'app')
-        File.copy(src=src, target=target)
+        File.copy(source=src, target=target)
         Tns.platform_add_android(app_name=cls.app_name, framework_path=Settings.Android.FRAMEWORK_PATH)
         if Settings.HOST_OS is OSType.OSX:
             Tns.platform_add_ios(app_name=cls.app_name, framework_path=Settings.IOS.FRAMEWORK_PATH)
@@ -36,10 +37,11 @@ class TnsRunJSTests(TnsRunTest):
         TnsRunTest.setUp(self)
         # "src" folder of TestApp will be restored before each test.
         # This will ensure failures in one test do not cause common failures.
-        source_src = os.path.join(self.target_project_dir, 'app')
-        target_src = os.path.join(self.source_project_dir, 'app')
-        Folder.clean(target_src)
-        Folder.copy(source=source_src, target=target_src)
+        for change in [Changes.JSHelloWord.CSS, Changes.JSHelloWord.XML, Changes.JSHelloWord.JS]:
+            source_src = os.path.join(self.target_project_dir, 'app', os.path.basename(change.file_path))
+            target_src = os.path.join(self.source_project_dir, change.file_path)
+            File.clean(path=target_src)
+            File.copy(source=source_src, target=target_src)
 
     def test_100_run_android(self):
         sync_hello_world_js(self.app_name, Platform.ANDROID, self.emu)

--- a/tests/cli/run/templates/hello_world_ng_tests.py
+++ b/tests/cli/run/templates/hello_world_ng_tests.py
@@ -24,10 +24,10 @@ class TnsRunNGTests(TnsRunTest):
         Tns.create(app_name=cls.app_name, template=Template.HELLO_WORLD_NG.local_package, update=True)
         src = os.path.join(Settings.TEST_RUN_HOME, 'assets', 'logs', 'hello-world-ng', 'main.ts')
         target = os.path.join(Settings.TEST_RUN_HOME, cls.app_name, 'src')
-        File.copy(src=src, target=target)
+        File.copy(source=src, target=target)
         src = os.path.join(Settings.TEST_RUN_HOME, 'assets', 'logs', 'hello-world-ng', 'items.component.ts')
         target = os.path.join(Settings.TEST_RUN_HOME, cls.app_name, 'src', 'app', 'item')
-        File.copy(src=src, target=target)
+        File.copy(source=src, target=target)
         Tns.platform_add_android(app_name=cls.app_name, framework_path=Settings.Android.FRAMEWORK_PATH)
         if Settings.HOST_OS is OSType.OSX:
             Tns.platform_add_ios(app_name=cls.app_name, framework_path=Settings.IOS.FRAMEWORK_PATH)

--- a/tests/cli/run/templates/hello_world_ts_tests.py
+++ b/tests/cli/run/templates/hello_world_ts_tests.py
@@ -6,6 +6,7 @@ from core.enums.os_type import OSType
 from core.enums.platform_type import Platform
 from core.settings import Settings
 from core.utils.file_utils import Folder, File
+from data.changes import Changes
 from data.sync.hello_world_js import sync_hello_world_ts
 from data.templates import Template
 from products.nativescript.tns import Tns
@@ -24,7 +25,7 @@ class TnsRunTSTests(TnsRunTest):
         Tns.create(app_name=cls.app_name, template=Template.HELLO_WORLD_TS.local_package, update=True)
         src = os.path.join(Settings.TEST_RUN_HOME, 'assets', 'logs', 'hello-world-ts', 'app.ts')
         target = os.path.join(Settings.TEST_RUN_HOME, cls.app_name, 'app')
-        File.copy(src=src, target=target)
+        File.copy(source=src, target=target)
         Tns.platform_add_android(app_name=cls.app_name, framework_path=Settings.Android.FRAMEWORK_PATH)
         if Settings.HOST_OS is OSType.OSX:
             Tns.platform_add_ios(app_name=cls.app_name, framework_path=Settings.IOS.FRAMEWORK_PATH)
@@ -36,10 +37,11 @@ class TnsRunTSTests(TnsRunTest):
         TnsRunTest.setUp(self)
         # "src" folder of TestApp will be restored before each test.
         # This will ensure failures in one test do not cause common failures.
-        source_src = os.path.join(self.target_project_dir, 'app')
-        target_src = os.path.join(self.source_project_dir, 'app')
-        Folder.clean(target_src)
-        Folder.copy(source=source_src, target=target_src)
+        for change in [Changes.TSHelloWord.CSS, Changes.TSHelloWord.XML, Changes.TSHelloWord.TS]:
+            source_src = os.path.join(self.target_project_dir, 'app', os.path.basename(change.file_path))
+            target_src = os.path.join(self.source_project_dir, change.file_path)
+            File.clean(path=target_src)
+            File.copy(source=source_src, target=target_src)
 
     def test_100_run_android(self):
         sync_hello_world_ts(self.app_name, Platform.ANDROID, self.emu)


### PR DESCRIPTION
When we copy app folder we also copy app resources, which cause app rebuilds.
Avoid app rebuilds by copy only file changes.