### PR TITLE
fix: base tests for test command on TnsRunTest

### DIFF
--- a/tests/cli/test/test_test.py
+++ b/tests/cli/test/test_test.py
@@ -14,7 +14,6 @@ from core.utils.npm import Npm
 from data.templates import Template
 from products.nativescript.tns import Tns
 from products.nativescript.tns_assert import TnsAssert
-from products.nativescript.tns_paths import TnsPaths
 
 APP_NAME = Settings.AppName.DEFAULT
 

--- a/tests/cli/test/test_test.py
+++ b/tests/cli/test/test_test.py
@@ -9,21 +9,21 @@ from core.base_test.tns_test import TnsTest
 from core.enums.framework_type import FrameworkType
 from core.enums.os_type import OSType
 from core.enums.platform_type import Platform
-from core.log.log import Log
 from core.settings import Settings
 from core.utils.device.device_manager import DeviceManager
 from core.utils.npm import Npm
 from data.templates import Template
 from products.nativescript.tns import Tns
 from products.nativescript.tns_assert import TnsAssert
+from products.nativescript.tns_paths import TnsPaths
 
 APP_NAME = Settings.AppName.DEFAULT
 
 TEST_DATA = [
-    ('jasmine-js-android', FrameworkType.JASMINE, Template.HELLO_WORLD_JS, Platform.ANDROID),
-    ('jasmine-ng-android', FrameworkType.JASMINE, Template.HELLO_WORLD_NG, Platform.ANDROID),
-    ('mocha-js-android', FrameworkType.MOCHA, Template.HELLO_WORLD_JS, Platform.ANDROID),
-    ('mocha-ng-android', FrameworkType.MOCHA, Template.HELLO_WORLD_NG, Platform.ANDROID),
+    # ('jasmine-js-android', FrameworkType.JASMINE, Template.HELLO_WORLD_JS, Platform.ANDROID),
+    # ('jasmine-ng-android', FrameworkType.JASMINE, Template.HELLO_WORLD_NG, Platform.ANDROID),
+    # ('mocha-js-android', FrameworkType.MOCHA, Template.HELLO_WORLD_JS, Platform.ANDROID),
+    # ('mocha-ng-android', FrameworkType.MOCHA, Template.HELLO_WORLD_NG, Platform.ANDROID),
     ('qunit-js-android', FrameworkType.QUNIT, Template.HELLO_WORLD_JS, Platform.ANDROID),
 ]
 
@@ -88,13 +88,13 @@ class TestsForTnsTest(TnsTest):
         else:
             Tns.test_init(app_name=APP_NAME, framework=framework)
 
+        # Handle Qunit
+        if framework == FrameworkType.QUNIT:
+            Npm.uninstall(package='karma-qunit', option='--save-dev', folder=TnsPaths.get_app_path(app_name=APP_NAME))
+            Npm.install(package='karma-qunit@2', option='--save-dev', folder=TnsPaths.get_app_path(app_name=APP_NAME))
+
         # Run Tests
-        if Settings.HOST_OS != OSType.WINDOWS:
-            Tns.test(app_name=APP_NAME, platform=Platform.ANDROID, emulator=True, justlaunch=True)
-            # TODO: Modify hello-world test with some real test (importing modules) and run the test again.
-        else:
-            Log.info('Due to unknown issues --justlauch do not exit on Windows when tests are executed on Jenkins!')
-            # TODO: Fix it!
+        Tns.test(app_name=APP_NAME, platform=Platform.ANDROID, emulator=True, justlaunch=True)
 
     def test_400_invalid_framework_name(self):
         result = Tns.create(app_name=APP_NAME, template=Template.MIN_JS.local_package, update=False, verify=False)

--- a/tests/cli/test/test_test.py
+++ b/tests/cli/test/test_test.py
@@ -5,12 +5,11 @@ import os
 
 from parameterized import parameterized
 
-from core.base_test.tns_test import TnsTest
+from core.base_test.tns_run_test import TnsRunTest
 from core.enums.framework_type import FrameworkType
 from core.enums.os_type import OSType
 from core.enums.platform_type import Platform
 from core.settings import Settings
-from core.utils.device.device_manager import DeviceManager
 from core.utils.npm import Npm
 from data.templates import Template
 from products.nativescript.tns import Tns
@@ -49,21 +48,7 @@ def get_data():
 
 
 # noinspection PyMethodMayBeStatic,PyUnusedLocal
-class TestsForTnsTest(TnsTest):
-
-    @classmethod
-    def setUpClass(cls):
-        TnsTest.setUpClass()
-        cls.emu = DeviceManager.Emulator.ensure_available(Settings.Emulators.DEFAULT)
-        if Settings.HOST_OS is OSType.OSX:
-            cls.sim = DeviceManager.Simulator.ensure_available(Settings.Simulators.DEFAULT)
-
-    def setUp(self):
-        TnsTest.setUp(self)
-
-    @classmethod
-    def tearDownClass(cls):
-        TnsTest.tearDownClass()
+class TestsForTnsTest(TnsRunTest):
 
     @parameterized.expand(get_data())
     def test_100(self, title, framework, template, platform):

--- a/tests/cli/test/test_test.py
+++ b/tests/cli/test/test_test.py
@@ -20,10 +20,10 @@ from products.nativescript.tns_paths import TnsPaths
 APP_NAME = Settings.AppName.DEFAULT
 
 TEST_DATA = [
-    # ('jasmine-js-android', FrameworkType.JASMINE, Template.HELLO_WORLD_JS, Platform.ANDROID),
-    # ('jasmine-ng-android', FrameworkType.JASMINE, Template.HELLO_WORLD_NG, Platform.ANDROID),
-    # ('mocha-js-android', FrameworkType.MOCHA, Template.HELLO_WORLD_JS, Platform.ANDROID),
-    # ('mocha-ng-android', FrameworkType.MOCHA, Template.HELLO_WORLD_NG, Platform.ANDROID),
+    ('jasmine-js-android', FrameworkType.JASMINE, Template.HELLO_WORLD_JS, Platform.ANDROID),
+    ('jasmine-ng-android', FrameworkType.JASMINE, Template.HELLO_WORLD_NG, Platform.ANDROID),
+    ('mocha-js-android', FrameworkType.MOCHA, Template.HELLO_WORLD_JS, Platform.ANDROID),
+    ('mocha-ng-android', FrameworkType.MOCHA, Template.HELLO_WORLD_NG, Platform.ANDROID),
     ('qunit-js-android', FrameworkType.QUNIT, Template.HELLO_WORLD_JS, Platform.ANDROID),
 ]
 

--- a/tests/cli/test/test_test.py
+++ b/tests/cli/test/test_test.py
@@ -73,11 +73,6 @@ class TestsForTnsTest(TnsRunTest):
         else:
             Tns.test_init(app_name=APP_NAME, framework=framework)
 
-        # Handle Qunit
-        if framework == FrameworkType.QUNIT:
-            Npm.uninstall(package='karma-qunit', option='--save-dev', folder=TnsPaths.get_app_path(app_name=APP_NAME))
-            Npm.install(package='karma-qunit@2', option='--save-dev', folder=TnsPaths.get_app_path(app_name=APP_NAME))
-
         # Run Tests
         Tns.test(app_name=APP_NAME, platform=Platform.ANDROID, emulator=True, justlaunch=True)
 


### PR DESCRIPTION
Refactoring:
- Base tests on `TnsRunTest`

Fix:
- Execute tests on Windows (there where no executed previously because of issue with tests with --justlauch on Windows).