### PR TITLE
fix: tests for master detail templates

### DIFF
--- a/data/changes.py
+++ b/data/changes.py
@@ -66,7 +66,7 @@ class Changes(object):
     class MasterDetailNG(object):
         TS = ChangeSet(file_path=os.path.join('src', 'app', 'cars', 'shared', 'car.model.ts'),
                        old_value='options.name;', new_value='"SyncTSTest";',
-                       old_text='BMW 5 Series', new_text='SyncTSTest')
+                       old_text='Ford KA', new_text='SyncTSTest')
         HTML = ChangeSet(file_path=os.path.join('src', 'app', 'cars', 'car-list.component.html'),
                          old_value='Browse', new_value='Best Car Ever!',
                          old_text='Browse', new_text='Best Car Ever!')

--- a/data/templates.py
+++ b/data/templates.py
@@ -14,7 +14,7 @@ class Template(object):
     # Texts used in templates
     hw_js = ['TAP']
     hw_ng = ['Ter Stegen']
-    md_str = ['BMW 5 Series']
+    md_str = ['Ford KA']
     dr_str = ['Home']
     tn_str = ['Item 1']
     login = ['Login']


### PR DESCRIPTION
When we execute tests on Xcode9 machines we use iPhone7 simulator.
BMW is not displayed on this device because resolution is lower compared to iPhone X.

Test with `Ford KA` instead of `BMW 5 Series`.