### PR TITLE
fix: tests for live templates

### DIFF
--- a/tests/templates/template_tests.py
+++ b/tests/templates/template_tests.py
@@ -86,6 +86,9 @@ class TemplateTests(TnsRunTest):
             Simctl.uninstall_all(simulator_info=self.sim)
             result = Tns.run_ios(app_name=app_name, device=self.sim.id, bundle=True)
             strings = TnsLogs.run_messages(app_name=app_name, run_type=RunType.FULL, platform=Platform.IOS, bundle=True)
+            if template_info == Template.DRAWER_NAVIGATION_NG:
+                strings = TnsLogs.run_messages(app_name=app_name, run_type=RunType.UNKNOWN, platform=Platform.IOS,
+                                               bundle=True)
             TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=300)
             if template_info.texts is not None:
                 for text in template_info.texts:


### PR DESCRIPTION
This job is failing:
http://nsbuild01:8080/build/view/Live%20View/job/live-templates/

Reason is we look for transfer of vendor.js, while we have thsi in logs:
```
Successfully transferred all files on device 7F78ED16-59F8-4A41-9AD7-58F679CEC6AC.
```
This happens because in this tempalete we have a lot of lazy loaded modules.