### PR TITLE
fix pattern_exists method

### DIFF
--- a/core/utils/file_utils.py
+++ b/core/utils/file_utils.py
@@ -196,7 +196,7 @@ class File(object):
             for basename in files:
                 if fnmatch.fnmatch(basename, pattern):
                     filename = os.path.join(root, basename)
-                    print pattern + " exists: " + filename
+                    Log.info(pattern + " exists: " + filename)
                     found = True
         return found
 


### PR DESCRIPTION
With python3 print method requires parenthesis.
Use log info method instead to unify runs with different python versions.