### PR TITLE
fix: tns logs for android 7.0+ emulators and devices

### DIFF
--- a/core/utils/device/adb.py
+++ b/core/utils/device/adb.py
@@ -9,6 +9,7 @@ from core.settings import Settings
 from core.utils.file_utils import File
 from core.utils.process import Process
 from core.utils.run import run
+from core.utils.version import Version
 
 ANDROID_HOME = os.environ.get('ANDROID_HOME')
 ADB_PATH = os.path.join(ANDROID_HOME, 'platform-tools', 'adb')
@@ -326,7 +327,7 @@ class Adb(object):
     def get_version(device_id):
         """
         Get device version
-        :param device_id: Device identifier
+        :param device_id: Device identifier as float.
         """
-        command = " -s " + device_id + " shell getprop ro.build.version.release "
-        return Adb.run_adb_command(command=command, wait=True).output
+        result = Adb.run_adb_command(command='shell getprop ro.build.version.release', wait=True, device_id=device_id)
+        return Version.get(result.output)

--- a/core/utils/device/device_manager.py
+++ b/core/utils/device/device_manager.py
@@ -19,7 +19,8 @@ class DeviceManager(object):
         # Get Android devices
         if device_type is DeviceType.ANDROID or device_type is any:
             for device_id in Adb.get_ids(include_emulators=False):
-                device = Device(id=device_id, name=device_id, type=DeviceType.ANDROID, version=None)
+                version = Adb.get_version(device_id=device_id)
+                device = Device(id=device_id, name=device_id, type=DeviceType.ANDROID, version=version)
                 devices.append(device)
         # Get iOS devices
         if device_type is DeviceType.IOS or device_type is any:

--- a/core_tests/unit/product/tns_helpers_tests.py
+++ b/core_tests/unit/product/tns_helpers_tests.py
@@ -1,8 +1,10 @@
 import os
 import unittest
 
+from core.enums.device_type import DeviceType
 from core.enums.platform_type import Platform
 from core.settings import Settings
+from core.utils.device.device import Device
 from data.changes import Changes
 from products.nativescript.run_type import RunType
 from products.nativescript.tns_logs import TnsLogs
@@ -26,7 +28,8 @@ class SyncMessagesTests(unittest.TestCase):
         logs = TnsLogs.run_messages(app_name='QAApp',
                                     platform=Platform.ANDROID,
                                     run_type=RunType.FIRST_TIME,
-                                    file_name=None)
+                                    file_name=None,
+                                    device=Device(id='123', name='Emu', type=DeviceType.EMU, version=6.0))
         assert 'Skipping prepare.' not in logs
         assert 'Preparing project...' in logs
         assert 'Project successfully prepared (Android)' in logs
@@ -46,14 +49,15 @@ class SyncMessagesTests(unittest.TestCase):
         logs = TnsLogs.run_messages(app_name=Settings.AppName.DEFAULT,
                                     platform=Platform.ANDROID,
                                     run_type=RunType.INCREMENTAL,
-                                    file_name='main-view-model.js')
+                                    file_name='main-view-model.js',
+                                    device=Device(id='123', name='Emu', type=DeviceType.EMU, version=8.0))
         assert 'Preparing project...' in logs
         assert 'Project successfully prepared (Android)' in logs
         assert 'Successfully transferred main-view-model.js' in logs
         assert 'Restarting application on device' in logs
         assert 'Successfully synced application org.nativescript.TestApp on device' in logs
-        assert 'ActivityManager: Start proc' in logs
-        assert 'activity org.nativescript.TestApp/com.tns.NativeScriptActivity' in logs
+        assert 'ActivityManager: Start proc' not in logs
+        assert 'activity org.nativescript.TestApp/com.tns.NativeScriptActivity' not in logs
 
     def test_12_get_run_messages_sync_js_bundle(self):
         logs = TnsLogs.run_messages(app_name=Settings.AppName.DEFAULT,
@@ -70,17 +74,17 @@ class SyncMessagesTests(unittest.TestCase):
         assert 'Successfully transferred vendor.js' not in logs
         assert 'Restarting application on device' in logs
         assert 'Successfully synced application org.nativescript.TestApp on device' in logs
-        assert 'ActivityManager: Start proc' in logs
-        assert 'activity org.nativescript.TestApp/com.tns.NativeScriptActivity' in logs
         assert 'Refreshing application on device' not in logs
         assert 'hot-update.json on device' not in logs
 
-    def test_12_get_run_messages_sync_js_bundle_uglify(self):
+    def test_13_get_run_messages_sync_js_bundle_uglify(self):
         logs = TnsLogs.run_messages(app_name=Settings.AppName.DEFAULT,
                                     platform=Platform.ANDROID,
                                     run_type=RunType.INCREMENTAL,
                                     file_name='main-view-model.js',
-                                    bundle=True, uglify=True)
+                                    bundle=True,
+                                    uglify=True,
+                                    device=Device(id='123', name='Emu', type=DeviceType.EMU, version=4.4))
         assert 'Skipping prepare.' not in logs
         assert 'File change detected.' in logs
         assert 'main-view-model.js' in logs
@@ -96,7 +100,7 @@ class SyncMessagesTests(unittest.TestCase):
         assert 'Refreshing application on device' not in logs
         assert 'hot-update.json on device' not in logs
 
-    def test_13_get_run_messages_sync_js_hmr(self):
+    def test_14_get_run_messages_sync_js_hmr(self):
         logs = TnsLogs.run_messages(app_name=Settings.AppName.DEFAULT,
                                     platform=Platform.ANDROID,
                                     run_type=RunType.INCREMENTAL,
@@ -114,14 +118,14 @@ class SyncMessagesTests(unittest.TestCase):
         assert 'Successfully transferred bundle.js on device' not in logs
         assert 'Restarting application on device' not in logs
 
-    def test_14_get_run_messages_sync_xml_bundle_no_hmr(self):
+    def test_15_get_run_messages_sync_xml_bundle_no_hmr(self):
         logs = TnsLogs.run_messages(app_name=Settings.AppName.DEFAULT, platform=Platform.ANDROID,
                                     run_type=RunType.INCREMENTAL, bundle=True, hmr=False, file_name='main-page.xml',
                                     instrumented=True)
         assert 'Refreshing application on device' not in logs
         assert 'Restarting application on device' in logs
 
-    def test_15_get_run_messages_sync_xml_bundle_and_uglify(self):
+    def test_16_get_run_messages_sync_xml_bundle_and_uglify(self):
         logs = TnsLogs.run_messages(app_name=Settings.AppName.DEFAULT, platform=Platform.ANDROID,
                                     run_type=RunType.INCREMENTAL, bundle=True, hmr=False, uglify=True,
                                     file_name='main-page.xml',
@@ -129,7 +133,7 @@ class SyncMessagesTests(unittest.TestCase):
         assert 'Refreshing application on device' not in logs
         assert 'Restarting application on device' in logs
 
-    def test_16_get_run_messages_sync_js(self):
+    def test_17_get_run_messages_sync_js(self):
         logs = TnsLogs.run_messages(app_name=Settings.AppName.DEFAULT,
                                     platform=Platform.ANDROID,
                                     run_type=RunType.INCREMENTAL,
@@ -138,7 +142,7 @@ class SyncMessagesTests(unittest.TestCase):
         assert 'Skipping prepare.' not in logs
         assert 'Successfully transferred main-view-model.js' in logs
 
-    def test_17_get_run_messages_sync_ts(self):
+    def test_18_get_run_messages_sync_ts(self):
         logs = TnsLogs.run_messages(app_name=Settings.AppName.DEFAULT,
                                     platform=Platform.ANDROID,
                                     run_type=RunType.INCREMENTAL,
@@ -147,7 +151,7 @@ class SyncMessagesTests(unittest.TestCase):
         assert 'Skipping prepare.' not in logs
         assert 'Successfully transferred main-view-model.js' in logs
 
-    def test_18_get_run_messages_incremental_prepare(self):
+    def test_19_get_run_messages_incremental_prepare(self):
         logs = TnsLogs.run_messages(app_name=Settings.AppName.DEFAULT,
                                     platform=Platform.ANDROID,
                                     run_type=RunType.INCREMENTAL,

--- a/data/sync/hello_world_js.py
+++ b/data/sync/hello_world_js.py
@@ -67,7 +67,7 @@ def __sync_hello_world_js_ts(app_type, app_name, platform, device,
     __verify_snapshot_skipped(snapshot, result)
 
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.UNKNOWN, bundle=bundle,
-                                   hmr=hmr, instrumented=instrumented)
+                                   hmr=hmr, instrumented=instrumented, device=device)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=240)
 
     # Verify it looks properly
@@ -82,7 +82,7 @@ def __sync_hello_world_js_ts(app_type, app_name, platform, device,
     Sync.replace(app_name=app_name, change_set=js_change)
     device.wait_for_text(text=js_change.new_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
-                                   hmr=hmr, file_name=js_file, instrumented=instrumented)
+                                   hmr=hmr, file_name=js_file, instrumented=instrumented, device=device)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
 
     # Edit XML file and verify changes are applied
@@ -90,7 +90,7 @@ def __sync_hello_world_js_ts(app_type, app_name, platform, device,
     device.wait_for_text(text=xml_change.new_text)
     device.wait_for_text(text=js_change.new_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
-                                   hmr=hmr, file_name='main-page.xml', instrumented=instrumented)
+                                   hmr=hmr, file_name='main-page.xml', instrumented=instrumented, device=device)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
 
     # Edit CSS file and verify changes are applied
@@ -99,7 +99,7 @@ def __sync_hello_world_js_ts(app_type, app_name, platform, device,
     device.wait_for_text(text=xml_change.new_text)
     device.wait_for_text(text=js_change.new_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
-                                   hmr=hmr, file_name='app.css', instrumented=instrumented)
+                                   hmr=hmr, file_name='app.css', instrumented=instrumented, device=device)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
 
     # Revert all the changes
@@ -107,14 +107,14 @@ def __sync_hello_world_js_ts(app_type, app_name, platform, device,
     device.wait_for_text(text=js_change.old_text)
     device.wait_for_text(text=xml_change.new_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
-                                   hmr=hmr, file_name=js_file, instrumented=instrumented)
+                                   hmr=hmr, file_name=js_file, instrumented=instrumented, device=device)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
 
     Sync.revert(app_name=app_name, change_set=xml_change)
     device.wait_for_text(text=xml_change.old_text)
     device.wait_for_text(text=js_change.old_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
-                                   hmr=hmr, file_name='main-page.xml', instrumented=instrumented)
+                                   hmr=hmr, file_name='main-page.xml', instrumented=instrumented, device=device)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
 
     Sync.revert(app_name=app_name, change_set=css_change)
@@ -122,7 +122,7 @@ def __sync_hello_world_js_ts(app_type, app_name, platform, device,
     device.wait_for_text(text=xml_change.old_text)
     device.wait_for_text(text=js_change.old_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
-                                   hmr=hmr, file_name='app.css', instrumented=instrumented)
+                                   hmr=hmr, file_name='app.css', instrumented=instrumented, device=device)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
 
     # Assert final and initial states are same

--- a/data/sync/hello_world_ng.py
+++ b/data/sync/hello_world_ng.py
@@ -30,7 +30,7 @@ def sync_hello_world_ng(app_name, platform, device, bundle=False, uglify=False, 
                      bundle=bundle, aot=aot, uglify=uglify, hmr=hmr)
     # Check logs
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.UNKNOWN, bundle=bundle,
-                                   hmr=hmr, instrumented=instrumented, app_type=AppType.NG)
+                                   hmr=hmr, instrumented=instrumented, app_type=AppType.NG, device=device)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=300)
 
     # Verify it looks properly
@@ -43,7 +43,8 @@ def sync_hello_world_ng(app_name, platform, device, bundle=False, uglify=False, 
     Sync.replace(app_name=app_name, change_set=Changes.NGHelloWorld.TS)
     device.wait_for_text(text=Changes.NGHelloWorld.TS.new_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
-                                   file_name='item.service.ts', hmr=hmr, instrumented=instrumented, app_type=AppType.NG)
+                                   file_name='item.service.ts', hmr=hmr, instrumented=instrumented, app_type=AppType.NG,
+                                   device=device)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
 
     Sync.replace(app_name=app_name, change_set=Changes.NGHelloWorld.HTML)
@@ -56,7 +57,7 @@ def sync_hello_world_ng(app_name, platform, device, bundle=False, uglify=False, 
     assert not device.is_text_visible(text=Changes.NGHelloWorld.TS.new_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    file_name='items.component.html', hmr=hmr, instrumented=instrumented,
-                                   app_type=AppType.NG, aot=aot)
+                                   app_type=AppType.NG, aot=aot, device=device)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
 
     Sync.replace(app_name=app_name, change_set=Changes.NGHelloWorld.CSS)
@@ -69,7 +70,8 @@ def sync_hello_world_ng(app_name, platform, device, bundle=False, uglify=False, 
             device.wait_for_text(text=number)
     assert not device.is_text_visible(text=Changes.NGHelloWorld.TS.new_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
-                                   file_name='app.css', hmr=hmr, instrumented=instrumented, app_type=AppType.NG)
+                                   file_name='app.css', hmr=hmr, instrumented=instrumented, app_type=AppType.NG,
+                                   device=device)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
 
     # Revert changes
@@ -77,21 +79,23 @@ def sync_hello_world_ng(app_name, platform, device, bundle=False, uglify=False, 
     device.wait_for_text(text=Changes.NGHelloWorld.TS.new_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    file_name='items.component.html', hmr=hmr, instrumented=instrumented,
-                                   app_type=AppType.NG, aot=aot)
+                                   app_type=AppType.NG, aot=aot, device=device)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
 
     Sync.revert(app_name=app_name, change_set=Changes.NGHelloWorld.TS)
     device.wait_for_text(text=Changes.NGHelloWorld.TS.old_text)
     device.wait_for_main_color(color=Colors.DARK)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
-                                   file_name='item.service.ts', hmr=hmr, instrumented=instrumented, app_type=AppType.NG)
+                                   file_name='item.service.ts', hmr=hmr, instrumented=instrumented, app_type=AppType.NG,
+                                   device=device)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
 
     Sync.revert(app_name=app_name, change_set=Changes.NGHelloWorld.CSS)
     device.wait_for_main_color(color=Colors.WHITE)
     device.wait_for_text(text=Changes.NGHelloWorld.TS.old_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
-                                   file_name='app.css', hmr=hmr, instrumented=instrumented, app_type=AppType.NG)
+                                   file_name='app.css', hmr=hmr, instrumented=instrumented, app_type=AppType.NG,
+                                   device=device)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
 
     # Assert final and initial states are same

--- a/products/nativescript/tns_logs.py
+++ b/products/nativescript/tns_logs.py
@@ -51,7 +51,7 @@ class TnsLogs(object):
 
     @staticmethod
     def run_messages(app_name, platform, run_type=RunType.FULL, bundle=False, hmr=False, uglify=False, app_type=None,
-                     file_name=None, instrumented=False, plugins=None, aot=False):
+                     file_name=None, instrumented=False, plugins=None, aot=False, device=None):
         """
         Get log messages that should be present when running a project.
         :param app_name: Name of the app (for example TestApp).
@@ -65,6 +65,7 @@ class TnsLogs(object):
         :param instrumented: If true it will return logs we place inside app (see files in assets/logs).
         :param plugins: List of plugins.
         :param aot: True if `--env.aot is specified.`
+        :param device: Device object.
         :return: Array of strings.
         """
         if plugins is None:
@@ -96,7 +97,7 @@ class TnsLogs(object):
         else:
             if TnsLogs.__should_restart(run_type=run_type, bundle=bundle, hmr=hmr, file_name=file_name):
                 logs.extend(TnsLogs.__app_restart_messages(app_name=app_name, platform=platform,
-                                                           instrumented=instrumented, app_type=app_type))
+                                                           instrumented=instrumented, app_type=app_type, device=device))
             else:
                 logs.extend(TnsLogs.__app_refresh_messages(instrumented=instrumented, app_type=app_type,
                                                            file_name=file_name, hmr=hmr))
@@ -187,12 +188,13 @@ class TnsLogs(object):
         return should_restart
 
     @staticmethod
-    def __app_restart_messages(app_name, platform, instrumented, app_type):
+    def __app_restart_messages(app_name, platform, instrumented, app_type, device):
         logs = ['Restarting application on device']
         if platform == Platform.ANDROID:
             app_id = TnsPaths.get_bundle_id(app_name)
-            logs.append('ActivityManager: Start proc')
-            logs.append('activity {0}/com.tns.NativeScriptActivity'.format(app_id))
+            if device is not None and device.version < 7.0:
+                logs.append('ActivityManager: Start proc')
+                logs.append('activity {0}/com.tns.NativeScriptActivity'.format(app_id))
         if instrumented:
             logs.append('QA: Application started')
             if app_type == AppType.NG:


### PR DESCRIPTION
On Android 7.0+ we do not show logs that happens very early in app live cycle.
For example: no more `ActivityManager: Start proc` on new devices.

Fixes:
- Adb.get_version() now returns float instead of string
- Get version when initialize device with DeviceManager
- Pass `device` to helper methods that get logs
- `__app_restart_messages` now do not return `ActivityManager: Start proc` for new devices