### PR TITLE
chore: set --no-hmr in vue tests for Android

### DIFF
--- a/tests/vue/test_vue_run.py
+++ b/tests/vue/test_vue_run.py
@@ -39,7 +39,7 @@ class VueJSTests(TnsRunTest):
         Folder.copy(source=source_src, target=target_src)
 
     def test_100_run_android(self):
-        sync_blank_vue(self.app_name, Platform.ANDROID, self.emu)
+        sync_blank_vue(self.app_name, Platform.ANDROID, self.emu, hmr=False)
 
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_100_run_ios(self):


### PR DESCRIPTION
We have known issues with hmr in vue (see https://github.com/nativescript-vue/nativescript-vue/issues/470).

Set `--no-hmr` in vue tests until issue above is fixed.