### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# CLI team owns the tests, so QAs within the team must review changes in the core directory
+/core @endarova @dtopuzov @miroslavaivanova


### PR DESCRIPTION
Add CODEOWNERS to the repo. The repo is set to require review from CODEOWNERS when there are such. I've added QAs from CLI team to own the core directory of the repo, as the methods there are crucial for running smooth CLI tests and each change there must be checked by the people who have the required knowledge.