### PR TITLE
chore: remove flaky logic in Adb.get_screen()

### DIFF
--- a/core/utils/device/adb.py
+++ b/core/utils/device/adb.py
@@ -211,18 +211,10 @@ class Adb(object):
     @staticmethod
     def get_screen(device_id, file_path):
         File.delete(path=file_path)
-        if 'emulator' in device_id:
-            if Settings.HOST_OS == OSType.WINDOWS:
-                Adb.run_adb_command(command='exec-out screencap -p > ' + file_path,
-                                    device_id=device_id,
-                                    log_level=logging.DEBUG)
-            else:
-                if Version.is_os_mojave():
-                    command = "shell screencap -p | perl -pe \\'s/\\x0D\\x0A/\\x0A/g\\' > " + file_path
-                    Adb.run_adb_command(command=command, device_id=device_id)
-                else:
-                    Adb.run_adb_command(command="shell screencap -p | perl -pe 's/\\x0D\\x0A/\\x0A/g' > " + file_path,
-                                        device_id=device_id)
+        if Settings.HOST_OS == OSType.WINDOWS:
+            Adb.run_adb_command(command='exec-out screencap -p > ' + file_path,
+                                device_id=device_id,
+                                log_level=logging.DEBUG)
         else:
             Adb.run_adb_command(command='shell rm /sdcard/image.png', device_id=device_id)
             Adb.run_adb_command(command='shell screencap -p /sdcard/image.png', device_id=device_id)

--- a/core/utils/device/adb.py
+++ b/core/utils/device/adb.py
@@ -211,7 +211,7 @@ class Adb(object):
     @staticmethod
     def get_screen(device_id, file_path):
         File.delete(path=file_path)
-        if Settings.HOST_OS == OSType.WINDOWS:
+        if Settings.HOST_OS == OSType.WINDOWS and 'emulator' in device_id:
             Adb.run_adb_command(command='exec-out screencap -p > ' + file_path,
                                 device_id=device_id,
                                 log_level=logging.DEBUG)

--- a/core/utils/version.py
+++ b/core/utils/version.py
@@ -20,18 +20,3 @@ class Version(object):
             return float(split[0] + '.' + split[1])
         else:
             return float(split[0])
-
-    @staticmethod
-    def is_os_mojave():
-        """
-        Check whether a machine OS is Mac Mojave.
-        :return: boolean.
-        """
-        is_machine_mojave = False
-        if Settings.HOST_OS is OSType.OSX:
-            version, _, _ = platform.mac_ver()
-            version = float('.'.join(version.split('.')[:2]))
-            if version == 10.14:
-                is_machine_mojave = True
-
-        return is_machine_mojave

--- a/core/utils/version.py
+++ b/core/utils/version.py
@@ -1,10 +1,6 @@
 """
 Version utils
 """
-import platform
-
-from core.enums.os_type import OSType
-from core.settings import Settings
 
 
 class Version(object):


### PR DESCRIPTION
We tried to optimize get screneshot by getting it as stream and forward to file on host machines.
This is faster than get screenshot on sdcard and pull it.


We found on some machines and our assumption was it it because of update to macOS Mohave,
It turned out that that is not the reason.

Fall back to old logic that get screenshot on sdcard and pull it.
It is slower, but looks to be more stable.