### PR TITLE
fix: master-detail-vue tests

### DIFF
--- a/run_common.py
+++ b/run_common.py
@@ -42,7 +42,7 @@ def __get_templates():
     Git.clone(repo_url=Template.REPO, branch='master', local_folder=local_folder)
 
     apps = [Template.HELLO_WORLD_JS, Template.HELLO_WORLD_TS, Template.HELLO_WORLD_NG, Template.MASTER_DETAIL_NG,
-            Template.VUE_BLANK]
+            Template.VUE_BLANK, Template.VUE_MASTER_DETAIL]
     for app in apps:
         template_name = app.name
         template_folder = os.path.join(local_folder, 'packages', template_name)

--- a/tests/vue/test_vue_blank_run.py
+++ b/tests/vue/test_vue_blank_run.py
@@ -11,7 +11,7 @@ from data.templates import Template
 from products.nativescript.tns import Tns
 
 
-class VueJSTests(TnsRunTest):
+class VueJSHelloWorldTests(TnsRunTest):
     app_name = Settings.AppName.DEFAULT
     source_project_dir = os.path.join(Settings.TEST_RUN_HOME, app_name)
     target_project_dir = os.path.join(Settings.TEST_RUN_HOME, 'data', 'temp', app_name)

--- a/tests/vue/test_vue_master_detail_run.py
+++ b/tests/vue/test_vue_master_detail_run.py
@@ -11,7 +11,7 @@ from data.templates import Template
 from products.nativescript.tns import Tns
 
 
-class VueJSTests(TnsRunTest):
+class VueJSMasterDetailTests(TnsRunTest):
     app_name = Settings.AppName.DEFAULT
     source_project_dir = os.path.join(Settings.TEST_RUN_HOME, app_name)
     target_project_dir = os.path.join(Settings.TEST_RUN_HOME, 'data', 'temp', app_name)

--- a/tests/vue/test_vue_master_detail_run.py
+++ b/tests/vue/test_vue_master_detail_run.py
@@ -7,7 +7,6 @@ from core.enums.platform_type import Platform
 from core.settings import Settings
 from core.utils.file_utils import Folder
 from data.sync.master_detail_vue import sync_master_detail_vue
-
 from data.templates import Template
 from products.nativescript.tns import Tns
 
@@ -39,9 +38,9 @@ class VueJSTests(TnsRunTest):
         Folder.clean(target_src)
         Folder.copy(source=source_src, target=target_src)
 
-    def test_100_run_android_bundle_hmr(self):
-        sync_master_detail_vue(self.app_name, Platform.ANDROID, self.emu, bundle=True)
+    def test_100_run_android_bundle(self):
+        sync_master_detail_vue(self.app_name, Platform.ANDROID, self.emu)
 
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
-    def test_100_run_ios_bundle_hmr(self):
-        sync_master_detail_vue(self.app_name, Platform.IOS, self.sim, bundle=True, hmr=True)
+    def test_100_run_ios_bundle(self):
+        sync_master_detail_vue(self.app_name, Platform.IOS, self.sim)


### PR DESCRIPTION
Template.VUE_MASTER_DETAIL.local_package was null because app is not packed by run_common.py script.

Fix:
- Ensure we pack Template.VUE_MASTER_DETAIL

Refactor:
- Do not explicitly pass bundle and hmr, since they are now used by default