### PR TITLE
fix: save exact version when install dependencies

### DIFF
--- a/products/nativescript/app.py
+++ b/products/nativescript/app.py
@@ -35,13 +35,13 @@ class App(object):
     def install_dependency(app_name, dependency, version='latest'):
         app_path = os.path.join(Settings.TEST_RUN_HOME, app_name)
         Npm.uninstall(package=dependency, option='--save', folder=app_path)
-        Npm.install(package='{0}@{1}'.format(dependency, version), option='--save', folder=app_path)
+        Npm.install(package='{0}@{1}'.format(dependency, version), option='--save --save-exact', folder=app_path)
 
     @staticmethod
     def install_dev_dependency(app_name, dependency, version='latest'):
         app_path = os.path.join(Settings.TEST_RUN_HOME, app_name)
         Npm.uninstall(package=dependency, option='--save-dev', folder=app_path)
-        Npm.install(package='{0}@{1}'.format(dependency, version), option='--save-dev', folder=app_path)
+        Npm.install(package='{0}@{1}'.format(dependency, version), option='--save-dev --save-exact', folder=app_path)
 
     @staticmethod
     def update(app_name, modules=True, angular=True, typescript=True, web_pack=True, vue=True):
@@ -49,17 +49,17 @@ class App(object):
         modules_path = os.path.join(app_path, 'node_modules')
         if modules and App.is_dependency(app_name=app_name, dependency='tns-core-modules'):
             Npm.uninstall(package='tns-core-modules', option='--save', folder=app_path)
-            Npm.install(package=Settings.Packages.MODULES, option='--save', folder=app_path)
+            Npm.install(package=Settings.Packages.MODULES, option='--save --save-exact', folder=app_path)
         if angular and App.is_dependency(app_name=app_name, dependency='nativescript-angular'):
             Npm.uninstall(package='nativescript-angular', option='--save', folder=app_path)
-            Npm.install(package=Settings.Packages.ANGULAR, option='--save', folder=app_path)
+            Npm.install(package=Settings.Packages.ANGULAR, option='--save --save-exact', folder=app_path)
             update_script = os.path.join(modules_path, '.bin', 'update-app-ng-deps')
             result = run(cmd=update_script, log_level=logging.INFO)
             assert 'Angular dependencies updated' in result.output, 'Angular dependencies not updated.'
             Npm.install(folder=app_path)
         if typescript and App.is_dev_dependency(app_name=app_name, dependency='nativescript-dev-typescript'):
             Npm.uninstall(package='nativescript-dev-typescript', option='--save-dev', folder=app_path)
-            Npm.install(package=Settings.Packages.TYPESCRIPT, option='--save-dev', folder=app_path)
+            Npm.install(package=Settings.Packages.TYPESCRIPT, option='--save-dev --save-exact', folder=app_path)
             update_script = os.path.join(modules_path, 'nativescript-dev-typescript', 'bin', 'ns-upgrade-tsconfig')
             result = run(cmd=update_script, log_level=logging.INFO)
             assert "Adding 'es6' lib to tsconfig.json..." in result.output
@@ -67,7 +67,7 @@ class App(object):
             assert 'Adding tns-core-modules path mappings lib' in result.output
         if web_pack and App.is_dev_dependency(app_name=app_name, dependency='nativescript-dev-webpack'):
             Npm.uninstall(package='nativescript-dev-webpack', option='--save-dev', folder=app_path)
-            Npm.install(package=Settings.Packages.WEBPACK, option='--save-dev', folder=app_path)
+            Npm.install(package=Settings.Packages.WEBPACK, option='--save-dev --save-exact', folder=app_path)
             update_script = os.path.join(modules_path, '.bin', 'update-ns-webpack') + ' --deps --configs'
             result = run(cmd=update_script, log_level=logging.INFO)
             assert 'Updating dev dependencies...' in result.output, 'Webpack dependencies not updated.'
@@ -75,4 +75,4 @@ class App(object):
             Npm.install(folder=app_path)
         if vue and App.is_dependency(app_name=app_name, dependency='nativescript-vue'):
             Npm.uninstall(package='nativescript-vue', option='--save', folder=app_path)
-            Npm.install(package='nativescript-vue@latest', option='--save', folder=app_path)
+            Npm.install(package='nativescript-vue@latest', option='--save --save-exact', folder=app_path)

--- a/products/nativescript/tns.py
+++ b/products/nativescript/tns.py
@@ -350,7 +350,7 @@ class Tns(object):
             TnsAssert.test_initialized(app_name=app_name, framework=framework, output=result.output)
         if update:
             Npm.uninstall(package='nativescript-unit-test-runner', option='--save', folder=app_path)
-            Npm.install(package='nativescript-unit-test-runner@next', option='--save', folder=app_path)
+            Npm.install(package='nativescript-unit-test-runner@next', option='--save --save-exact', folder=app_path)
         return result
 
     @staticmethod


### PR DESCRIPTION
When we install dependencies with `--save` it adds them with `^` which may lead to taking wrong version.
`--save --save-exact` should solve the issue.