### PR TITLE
chore: fix ios signing in some tests

### DIFF
--- a/tests/apps/apps_tests.py
+++ b/tests/apps/apps_tests.py
@@ -25,8 +25,6 @@ class SampleAppsTests(TnsTest):
         ('nativescript-sdk-examples-ng', 'NativeScript', 'NativeScript Code Samples'),
         ('nativescript-sdk-examples-js', 'NativeScript', 'Cookbook'),
         ('sample-Groceries', 'NativeScript', 'Login'),
-        # ('nativescript-marketplace-demo', 'NativeScript', 'GET STARTED'),
-        # Ignored because of https://github.com/NativeScript/nativescript-marketplace-demo/issues/301
     ]
 
     @classmethod
@@ -62,7 +60,8 @@ class SampleAppsTests(TnsTest):
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'Skip iOS core_tests on non macOS machines.')
     @parameterized.expand(test_data)
     def test_002_build_ios(self, repo, org, text):
-        Tns.build_ios(app_name=repo, release=True, for_device=True, bundle=True, aot=True, uglify=True)
+        Tns.build_ios(app_name=repo, release=True, for_device=True, bundle=True, aot=True, uglify=True,
+                      provision=Settings.IOS.PROVISIONING)
 
     @parameterized.expand(test_data)
     def test_003_run_android(self, repo, org, text):

--- a/tests/cli/regression/test_js_regressions.py
+++ b/tests/cli/regression/test_js_regressions.py
@@ -35,4 +35,5 @@ class JSRegressionTests(TnsRunTest):
 
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_201_build_ios_release(self):
-        Tns.build_ios(app_name=self.js_app, release=True, for_device=True, bundle=True, aot=True, uglify=True)
+        Tns.build_ios(app_name=self.js_app, release=True, for_device=True, bundle=True, aot=True, uglify=True,
+                      provision=Settings.IOS.PROVISIONING)

--- a/tests/cli/regression/test_ng_regressions.py
+++ b/tests/cli/regression/test_ng_regressions.py
@@ -49,4 +49,5 @@ class NGRegressionTests(TnsTest):
 
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_201_build_ios_release(self):
-        Tns.build_ios(app_name=self.ng_app, release=True, for_device=True, bundle=True, aot=True, uglify=True)
+        Tns.build_ios(app_name=self.ng_app, release=True, for_device=True, bundle=True, aot=True, uglify=True,
+                      provision=Settings.IOS.PROVISIONING)


### PR DESCRIPTION
After we merged https://github.com/NativeScript/nativescript-tooling-qa/pull/162 default value of provisioning is None which require passing it explicitly in tests.