### PR TITLE
fix: cocoapod tests

### DIFF
--- a/assets/issues/nativescript-cli-3650/main-view-model.js
+++ b/assets/issues/nativescript-cli-3650/main-view-model.js
@@ -1,0 +1,25 @@
+const Observable = require("tns-core-modules/data/observable").Observable;
+
+function getMessage(counter) {
+    if (counter <= 0) {
+        return "Hoorraaay! You unlocked the NativeScript clicker achievement!";
+    } else {
+        return `${counter} taps left`;
+    }
+}
+
+function createViewModel() {
+    const viewModel = new Observable();
+    viewModel.counter = 42;
+    viewModel.message = getMessage(viewModel.counter);
+    var objTC = new TestClass();
+    console.log(objTC.sayHey());
+    viewModel.onTap = () => {
+        viewModel.counter--;
+        viewModel.set("message", getMessage(viewModel.counter));
+    };
+
+    return viewModel;
+}
+
+exports.createViewModel = createViewModel;

--- a/assets/issues/nativescript-cli-4343/src/TestClass.h
+++ b/assets/issues/nativescript-cli-4343/src/TestClass.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+
+@interface TestClass : NSObject
+
+- (NSString *)sayHey;
+- (NSString *)sayName;
+- (NSString *)sayName:(NSString *)name;
+- (NSString *)say: (NSString *)name1 name: (NSString*)name2;
+
+@end

--- a/assets/issues/nativescript-cli-4343/src/TestClass.m
+++ b/assets/issues/nativescript-cli-4343/src/TestClass.m
@@ -1,0 +1,17 @@
+#import "TestClass.h"
+
+@implementation TestClass
+
+- (NSString *)sayHey{
+      return @"Hey Native!";
+}
+- (NSString *)sayName{
+    return @"SayName no param!";
+}
+- (NSString *)sayName:(NSString *)name{
+   return @"SayName with 1 param!";
+}
+- (NSString *)say: (NSString *)name1 name: (NSString*)name2 {
+    return @"SayName with 2 params!";
+}
+@end

--- a/assets/issues/nativescript-cli-4343/src/module.modulemap
+++ b/assets/issues/nativescript-cli-4343/src/module.modulemap
@@ -1,0 +1,5 @@
+module NativeScriptTests {
+    umbrella header "TestClass.h"
+    export *
+    module * { export * }
+}

--- a/data/changes.py
+++ b/data/changes.py
@@ -44,7 +44,7 @@ class Changes(object):
                                    old_value='My App', new_value='TestApp',
                                    old_text='My App', new_text='TestApp')
         XML_INVALID = ChangeSet(file_path=os.path.join('app', 'main-page.xml'),
-                                old_value='</Page>', new_value='</Page')
+                                old_value='</Page>', new_value='</Page ')
 
     class TSHelloWord(object):
         TS = ChangeSet(file_path=os.path.join('app', 'main-view-model.ts'),

--- a/products/nativescript/tns.py
+++ b/products/nativescript/tns.py
@@ -308,10 +308,10 @@ class Tns(object):
     @staticmethod
     def run_ios(app_name, emulator=False, device=None, release=False, provision=Settings.IOS.PROVISIONING,
                 for_device=False, bundle=True, hmr=True, aot=False, uglify=False, source_map=False, wait=False,
-                log_trace=False, just_launch=False, verify=True):
+                log_trace=False, just_launch=False, verify=True, clean=False):
         return Tns.run(app_name=app_name, platform=Platform.IOS, emulator=emulator, device=device, release=release,
                        provision=provision, for_device=for_device, bundle=bundle, hmr=hmr, aot=aot, uglify=uglify,
-                       source_map=source_map, wait=wait, log_trace=log_trace, just_launch=just_launch, verify=verify)
+                       source_map=source_map, wait=wait, log_trace=log_trace, just_launch=just_launch, verify=verify, clean=clean)
 
     @staticmethod
     def debug(app_name, platform, start=False, debug_brk=False, emulator=False, device=None, release=False,

--- a/products/nativescript/tns.py
+++ b/products/nativescript/tns.py
@@ -311,7 +311,8 @@ class Tns(object):
                 log_trace=False, just_launch=False, verify=True, clean=False):
         return Tns.run(app_name=app_name, platform=Platform.IOS, emulator=emulator, device=device, release=release,
                        provision=provision, for_device=for_device, bundle=bundle, hmr=hmr, aot=aot, uglify=uglify,
-                       source_map=source_map, wait=wait, log_trace=log_trace, just_launch=just_launch, verify=verify, clean=clean)
+                       source_map=source_map, wait=wait, log_trace=log_trace, just_launch=just_launch, verify=verify,
+                       clean=clean)
 
     @staticmethod
     def debug(app_name, platform, start=False, debug_brk=False, emulator=False, device=None, release=False,

--- a/products/nativescript/tns_paths.py
+++ b/products/nativescript/tns_paths.py
@@ -43,6 +43,10 @@ class TnsPaths(object):
     def get_platforms_android_app_path(app_name, path=Settings.TEST_RUN_HOME):
         return os.path.join(TnsPaths.get_platforms_android_folder(app_name=app_name, path=path), 'app', 'src', 'main',
                             'assets', 'app')
+    
+    @staticmethod
+    def get_platforms_ios_app_path(app_name, path=Settings.TEST_RUN_HOME):
+        return os.path.join(TnsPaths.get_platforms_ios_folder(app_name=app_name, path=path), app_name, 'app')
 
     @staticmethod
     def get_platforms_android_npm_modules(app_name, path=Settings.TEST_RUN_HOME):

--- a/products/nativescript/tns_paths.py
+++ b/products/nativescript/tns_paths.py
@@ -70,4 +70,10 @@ class TnsPaths(object):
 
     @staticmethod
     def get_bundle_id(app_name):
-        return 'org.nativescript.' + app_name.replace('-', '')
+        if '-' in app_name:
+            app_name = app_name.replace('-', '')
+        if ' ' in app_name:
+            app_name = app_name.replace(' ', '')
+        if '"' in app_name:
+            app_name = app_name.replace('"', '') 
+        return 'org.nativescript.' + app_name

--- a/products/nativescript/tns_paths.py
+++ b/products/nativescript/tns_paths.py
@@ -75,5 +75,5 @@ class TnsPaths(object):
         if ' ' in app_name:
             app_name = app_name.replace(' ', '')
         if '"' in app_name:
-            app_name = app_name.replace('"', '') 
+            app_name = app_name.replace('"', '')
         return 'org.nativescript.' + app_name

--- a/tests/cli/plugin/plugin_cocoapods_tests.py
+++ b/tests/cli/plugin/plugin_cocoapods_tests.py
@@ -44,7 +44,7 @@ class PluginCocoapodsTests(TnsTest):
                                             'package.json'))
             assert File.exists(os.path.join(TnsPaths.get_app_node_modules_path(self.app_name), 'carousel', 'platforms',
                                             'ios', 'Podfile'))
-            assert "carousel" in File.read(os.path.join(self.app_name, 'package.json'))
+            assert "carousel" in File.read(os.path.join(Settings.TEST_RUN_HOME, self.app_name, 'package.json'))
 
             plugin_path = os.path.join(Settings.TEST_RUN_HOME, 'assets', 'plugins', 'CocoaPods', 'keychain.tgz')
             result = Tns.plugin_add(plugin_path, path=Settings.AppName.DEFAULT)
@@ -53,12 +53,13 @@ class PluginCocoapodsTests(TnsTest):
                                             'package.json'))
             assert File.exists(os.path.join(TnsPaths.get_app_node_modules_path(self.app_name), 'keychain', 'platforms',
                                             'ios', 'Podfile'))
-            assert "keychain" in File.read(os.path.join(self.app_name, 'package.json'))
+            assert "keychain" in File.read(os.path.join(Settings.TEST_RUN_HOME, self.app_name, 'package.json'))
 
             result = Tns.prepare_ios(self.app_name)
             assert "Installing pods..." in result.output
-            assert "Successfully prepared plugin carousel for ios." in result.output
-            assert "Successfully prepared plugin keychain for ios." in result.output
+            # These asserts will be available again after we merge the webpack only branch for 6.0.0 release
+            # assert "Successfully prepared plugin carousel for ios." in result.output
+            # assert "Successfully prepared plugin keychain for ios." in result.output
 
             output = File.read(os.path.join(TnsPaths.get_platforms_ios_folder(self.app_name), 'Podfile'))
             assert "use_frameworks!" in output
@@ -119,12 +120,17 @@ class PluginCocoapodsTests(TnsTest):
             output = File.read(os.path.join(self.app_name, 'package.json'))
             assert "plugins/hello-plugin" in output
 
+            # Require the plugin so webpack can pick it up
+            main_js_file = os.path.join(Settings.TEST_RUN_HOME, self.app_name, 'app', 'main-page.js')
+            File.append(main_js_file, 'const hello = require("hello");')
+
             Tns.prepare_ios(self.app_name)
 
-            assert File.exists(os.path.join(TnsPaths.get_platforms_ios_folder(self.app_name), 'TestApp', 'app',
-                                            'tns_modules', 'hello', 'package.json'))
-            assert File.exists(os.path.join(TnsPaths.get_platforms_ios_folder(self.app_name), 'TestApp', 'app',
-                                            'tns_modules', 'hello', 'hello-plugin.js'))
+            bundle_js =  File.read(os.path.join(TnsPaths.get_platforms_ios_app_path(self.app_name), 'bundle.js'))
+            vendor_js =  File.read(os.path.join(TnsPaths.get_platforms_ios_app_path(self.app_name), 'vendor.js'))
+            assert '__webpack_require__("../node_modules/hello/hello-plugin.js")' in bundle_js
+            assert 'hello = Hello.alloc().init();' in vendor_js
+            
             result = run(
                 "cat " + os.path.join(TnsPaths.get_platforms_ios_folder(self.app_name), 'TestApp.xcodeproj',
                                       'project.pbxproj | grep \"HelloLib.a\"'))

--- a/tests/cli/preview/templates/hello_word_ng_tests.py
+++ b/tests/cli/preview/templates/hello_word_ng_tests.py
@@ -68,21 +68,21 @@ class PreviewNGTests(TnsPreviewNGTests):
     def test_200_preview_android_no_bundle(self):
         """Preview project on emulator with --bundle. Make valid changes in TS, CSS and HTML"""
         preview_sync_hello_world_ng(app_name=self.app_name, platform=Platform.ANDROID,
-                                    device=self.emu, instrumented=True, bundle=False, hmr=False)
+                                    device=self.emu, bundle=False, hmr=False)
 
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_200_preview_ios_no_bundle(self):
         """Preview project on simulator with --bundle. Make valid changes in TS, CSS and HTML"""
         preview_sync_hello_world_ng(app_name=self.app_name, platform=Platform.IOS,
-                                    device=self.sim, instrumented=True, bundle=False, hmr=False)
+                                    device=self.sim, bundle=False, hmr=False)
 
     def test_205_preview_android_no_hmr(self):
         """Preview project on emulator with --hmr. Make valid changes in TS, CSS and HTML"""
         preview_sync_hello_world_ng(app_name=self.app_name, platform=Platform.ANDROID,
-                                    device=self.emu, instrumented=True, hmr=False)
+                                    device=self.emu, hmr=False)
 
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_205_preview_ios_no_hmr(self):
         """Preview project on simulator with --hmr. Make valid changes in TS, CSS and HTML"""
         preview_sync_hello_world_ng(app_name=self.app_name, platform=Platform.IOS,
-                                    device=self.sim, instrumented=True, hmr=False)
+                                    device=self.sim, hmr=False)

--- a/tests/cli/run/tests/run_tests.py
+++ b/tests/cli/run/tests/run_tests.py
@@ -668,31 +668,6 @@ class TnsRunJSTests(TnsRunTest):
         else:
             raise nose.SkipTest('This test is not valid when devices are connected.')
 
-    @unittest.skipIf(Settings.HOST_OS == OSType.LINUX, '`shell cp -r` fails for some reason on emulators on Linux.')
-    def test_340_tns_run_android_should_respect_adb_errors(self):
-        """
-        If device memory is full and error is thrown during deploy cli should respect it
-        https://github.com/NativeScript/nativescript-cli/issues/2170
-        """
-        # Deploy the app to make sure we have something at /data/data/org.nativescript.TestApp
-        result = run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, just_launch=True)
-
-        # Use all the disk space on emulator
-        for index in range(1, 3000):
-            command = "shell cp -r /data/data/org.nativescript.TestApp /data/data/org.nativescript.TestApp" + str(index)
-            result = Adb.run_adb_command(device_id=self.emu.id, command=command)
-            Log.info(result.output)
-            if "No space left on device" in result.output:
-                break
-
-        # Create new app
-        Tns.create(app_name='TestApp2', template=Template.HELLO_WORLD_JS.local_package, update=False)
-
-        # Run the app and verify there is appropriate error
-        result = Tns.run_android('TestApp2', verify=True, device=self.emu.id, just_launch=True)
-        strings = ['No space left on device']
-        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_345_tns_run_ios_source_code_in_ios_part_plugin(self):
         """
@@ -759,9 +734,34 @@ class TnsRunJSTests(TnsRunTest):
         assert Folder.exists(node_modules)
 
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
-    def test_60_tns_run_ios_on_folder_with_spaces(self):
+    def test_360_tns_run_ios_on_folder_with_spaces(self):
         """
         `tns run ios` for apps with spaces
         """
         Tns.create(app_name=self.app_name_space, template=Template.HELLO_WORLD_JS.local_package, update=False)
         run_hello_world_js_ts(self.app_name_space, Platform.ANDROID, self.emu, just_launch=True)
+
+    @unittest.skipIf(Settings.HOST_OS == OSType.LINUX, '`shell cp -r` fails for some reason on emulators on Linux.')
+    def test_365_tns_run_android_should_respect_adb_errors(self):
+        """
+        If device memory is full and error is thrown during deploy cli should respect it
+        https://github.com/NativeScript/nativescript-cli/issues/2170
+        """
+        # Deploy the app to make sure we have something at /data/data/org.nativescript.TestApp
+        result = run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, just_launch=True)
+
+        # Use all the disk space on emulator
+        for index in range(1, 3000):
+            command = "shell cp -r /data/data/org.nativescript.TestApp /data/data/org.nativescript.TestApp" + str(index)
+            result = Adb.run_adb_command(device_id=self.emu.id, command=command)
+            Log.info(result.output)
+            if "No space left on device" in result.output:
+                break
+
+        # Create new app
+        Tns.create(app_name='TestApp2', template=Template.HELLO_WORLD_JS.local_package, update=False)
+
+        # Run the app and verify there is appropriate error
+        result = Tns.run_android('TestApp2', verify=True, device=self.emu.id, just_launch=True)
+        strings = ['No space left on device']
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)

--- a/tests/cli/run/tests/run_tests.py
+++ b/tests/cli/run/tests/run_tests.py
@@ -72,27 +72,27 @@ class TnsRunJSTests(TnsTest):
         """
         # Run app and verify on device
         result = run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu)
-    
+
         # Make changes in xml that will break the app
         Sync.replace(self.app_name, Changes.JSHelloWord.XML_INVALID)
         strings = ['main-page.xml', 'Error: Parsing XML']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text='Exception')
-    
+
         # Revert changes
         Sync.revert(self.app_name, Changes.JSHelloWord.XML_INVALID)
-    
+
         # Verify app is synced and recovered
         strings = ['Successfully synced application']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
         assert not self.emu.is_text_visible(text='Exception')
-    
+
         # Delete app.js and verify app crash with error activity dialog
         app_js_origin_path = os.path.join(self.source_project_dir, 'app', 'app.js')
         app_js_backup_path = os.path.join(self.target_project_dir, 'app', 'app.js')
         File.delete(app_js_origin_path)
-    
+
         # Verify app is synced
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID,
                                        device=self.emu, run_type=RunType.UNKNOWN)
@@ -106,7 +106,7 @@ class TnsRunJSTests(TnsTest):
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
         assert not self.emu.is_text_visible(text='Exception')
-    
+
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_100_run_ios_break_and_fix_app(self):
         """
@@ -115,20 +115,20 @@ class TnsRunJSTests(TnsTest):
         """
         # Run app and verify on device
         result = run_hello_world_js_ts(self.app_name, Platform.IOS, self.sim)
-    
+
         # Make changes in xml that will break the app
         Sync.replace(self.app_name, Changes.JSHelloWord.XML_INVALID)
         strings = ['main-page.xml', 'Error: Parsing XML']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-    
+
         # Revert changes
         Sync.revert(self.app_name, Changes.JSHelloWord.XML_INVALID)
-    
+
         # Verify app is synced and recovered
         strings = ['Successfully synced application']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.sim.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
-    
+
     @unittest.skipIf(Settings.HOST_OS == OSType.WINDOWS, 'skip on windows untill we fix wait_rof_log method')
     def test_105_tns_run_android_changes_in_app_resounces(self):
         """
@@ -137,18 +137,18 @@ class TnsRunJSTests(TnsTest):
         """
         # Run app and verify on device
         result = run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu)
-    
+
         # Make changes in AndroidManifest.xml
         manifest_path = os.path.join(self.app_resources_android, 'src', 'main', 'AndroidManifest.xml')
         File.replace(manifest_path, 'largeScreens="true"', 'largeScreens="false"')
-    
+
         # Verify rebuild is triggered and app is synced
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID,
                                        run_type=RunType.FULL, device=self.emu)
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
         self.emu.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
-    
+
         # Make changes in AppResources/Android
         File.copy(os.path.join(Settings.TEST_RUN_HOME, 'assets', 'resources', 'android', 'drawable-hdpi', 'icon.png'),
                   os.path.join(self.app_resources_android, 'src', 'main', 'res', 'drawable-hdpi', 'icon.png'))
@@ -158,7 +158,7 @@ class TnsRunJSTests(TnsTest):
         not_existing_strings = ['Xcode build']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_strings)
-    
+
         # https://github.com/NativeScript/nativescript-cli/issues/3658
         Tns.kill()
         # Make changes in AppResources/iOS
@@ -171,7 +171,7 @@ class TnsRunJSTests(TnsTest):
         not_existing_strings = ['Xcode build', 'Gradle build']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_strings)
-    
+
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_105_tns_run_ios_changes_in_app_resounces(self):
         """
@@ -180,18 +180,18 @@ class TnsRunJSTests(TnsTest):
         """
         # Run app and verify on device
         result = run_hello_world_js_ts(self.app_name, Platform.IOS, self.sim)
-    
+
         # Make changes in app resources, add aditional icon
         File.copy(os.path.join(Settings.TEST_RUN_HOME, 'assets', 'resources', 'ios', 'Default.png'),
                   os.path.join(self.app_resources_ios, 'Assets.xcassets', 'icon.png'))
-    
+
         # Verify rebuild is triggered and app is synced
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.IOS,
                                        run_type=RunType.FULL, device=self.sim)
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.sim.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
         self.sim.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
-    
+
         # Make changes in AppResources/IOS
         File.copy(os.path.join(os.path.join(Settings.TEST_RUN_HOME, 'assets', 'resources', 'ios', 'Default.png')),
                   os.path.join(self.app_resources_ios, 'Assets.xcassets', 'AppIcon.appiconset', 'icon-20.png'))
@@ -201,7 +201,7 @@ class TnsRunJSTests(TnsTest):
         not_existing_strings = ['Gradle build']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_strings)
-    
+
         # https://github.com/NativeScript/nativescript-cli/issues/3658
         Tns.kill()
         # Make changes in AppResources/Android
@@ -214,7 +214,7 @@ class TnsRunJSTests(TnsTest):
         not_existing_strings = ['Xcode build', 'Gradle build']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_strings)
-    
+
     def test_110_tns_run_android_release(self):
         # Run app and verify on device
         result = Tns.run_android(app_name=self.app_name, release=True, verify=True, emulator=True)
@@ -230,19 +230,19 @@ class TnsRunJSTests(TnsTest):
         self.emu.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
         blue_count = self.emu.get_pixels_by_color(color=Colors.LIGHT_BLUE)
         assert blue_count > 100, 'Failed to find blue color on {0}'.format(self.emu.name)
-    
+
         Tns.kill()
         # Make changes in js, css and xml files
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.JS)
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.XML)
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.CSS)
-    
+
         # Run with --release again and verify changes are deployed on device
         result = Tns.run_android(app_name=self.app_name, release=True, verify=True, emulator=True)
         self.emu.wait_for_text(text=Changes.JSHelloWord.JS.new_text)
         self.emu.wait_for_text(text=Changes.JSHelloWord.XML.new_text)
         self.emu.wait_for_color(color=Colors.LIGHT_BLUE, pixel_count=blue_count * 2, delta=25)
-    
+
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_110_tns_run_ios_release(self):
         # Run app and verify on device
@@ -256,19 +256,19 @@ class TnsRunJSTests(TnsTest):
         self.sim.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
         blue_count = self.sim.get_pixels_by_color(color=Colors.LIGHT_BLUE)
         assert blue_count > 100, 'Failed to find blue color on {0}'.format(self.sim.name)
-    
+
         Tns.kill()
         # Make changes in js, css and xml files
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.JS)
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.XML)
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.CSS)
-    
+
         # Run with --release again and verify changes are deployed on device
         result = Tns.run_ios(app_name=self.app_name, release=True, verify=True, emulator=True)
         self.sim.wait_for_text(text=Changes.JSHelloWord.JS.new_text)
         self.sim.wait_for_text(text=Changes.JSHelloWord.XML.new_text)
         self.sim.wait_for_color(color=Colors.LIGHT_BLUE, pixel_count=blue_count * 2, delta=25)
-    
+
     @unittest.skipIf(Settings.HOST_OS == OSType.WINDOWS, 'skip on windows untill we fix wait_rof_log method')
     def test_115_tns_run_android_add_remove_files_and_folders(self):
         """
@@ -276,7 +276,7 @@ class TnsRunJSTests(TnsTest):
         """
         # Run app and verify on device
         result = run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu)
-    
+
         # Add new file
         # To verify that file is synced on device we have to refer some function
         # from it and verify it is executed. We will use console.log
@@ -288,20 +288,20 @@ class TnsRunJSTests(TnsTest):
         File.append(app_js_file, "require('./test.js');")
         strings = ["JS: test.js synced!!!"]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-    
+
         # Rename file
         os.rename(new_file, renamed_file)
         File.replace(renamed_file, 'test.js', 'renamed file')
         File.replace(app_js_file, 'test.js', 'test_2.js')
         strings = ["JS: renamed file synced!!!"]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-    
+
         # Delete file
         File.delete(renamed_file)
         strings = ["Module build failed: Error: ENOENT", 'Successfully synced application']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text='Exception')
-    
+
         File.replace(app_js_file, "require('./test_2.js');", ' ')
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID,
                                        device=self.emu, run_type=RunType.UNKNOWN)
@@ -309,7 +309,7 @@ class TnsRunJSTests(TnsTest):
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_strings)
         self.emu.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
-    
+
         # Add folder
         folder_name = os.path.join(app_folder, 'test_folder')
         new_file = os.path.join(folder_name, 'test_in_folder.js')
@@ -318,13 +318,13 @@ class TnsRunJSTests(TnsTest):
         File.append(app_js_file, "require('./test_folder/test_in_folder.js');")
         strings = ["JS: test_in_folder.js synced!!!"]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-    
+
         # Delete folder
         Folder.clean(folder_name)
         strings = ["Module build failed: Error: ENOENT"]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text='Exception')
-    
+
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_115_tns_run_ios_add_remove_files_and_folders(self):
         """
@@ -332,7 +332,7 @@ class TnsRunJSTests(TnsTest):
         """
         # Run app and verify on device
         result = run_hello_world_js_ts(self.app_name, Platform.IOS, self.sim)
-    
+
         # Add new file
         # To verify that file is synced on device we have to refer some function
         # from it and verify it is executed. We will use console.log
@@ -344,19 +344,19 @@ class TnsRunJSTests(TnsTest):
         File.append(app_js_file, "require('./test.js');")
         strings = ["test.js synced!!!"]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-    
+
         # Rename file
         os.rename(new_file, renamed_file)
         File.replace(renamed_file, 'test.js', 'renamed file')
         File.replace(app_js_file, 'test.js', 'test_2.js')
         strings = ["renamed file synced!!!"]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-    
+
         # Delete file
         File.delete(renamed_file)
         strings = ["Module build failed: Error: ENOENT", "NativeScript debugger detached"]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-    
+
         File.replace(app_js_file, "require('./test_2.js');", ' ')
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.IOS,
                                        device=self.sim, run_type=RunType.UNKNOWN)
@@ -364,7 +364,7 @@ class TnsRunJSTests(TnsTest):
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_strings)
         self.sim.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
-    
+
         # Add folder
         folder_name = os.path.join(app_folder, 'test_folder')
         new_file = os.path.join(folder_name, 'test_in_folder.js')
@@ -374,12 +374,12 @@ class TnsRunJSTests(TnsTest):
         strings = ["test_in_folder.js synced!!!"]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.sim.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
-    
+
         # Delete folder
         Folder.clean(folder_name)
         strings = ["Module build failed: Error: ENOENT"]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-    
+
     def test_120_tns_run_android_just_launch(self):
         """
         This test verify following things:
@@ -392,7 +392,7 @@ class TnsRunJSTests(TnsTest):
         # On some machines it takes time for thr process to die
         time.sleep(5)
         assert not Process.is_running_by_name('node')
-    
+
         # Execute run with --justlaunch again and verify no rebuild is triggered
         result = Tns.run_android(app_name=self.app_name, emulator=True, just_launch=True)
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID,
@@ -401,18 +401,18 @@ class TnsRunJSTests(TnsTest):
         not_existing_strings = ['Preparing project...', 'Webpack compilation complete.']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_strings)
-    
+
         # Make changes in js, css and xml files
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.JS)
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.XML)
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.CSS)
-    
+
         # Execute run with --justlaunch again and verify prepare is triggered
         result = Tns.run_android(app_name=self.app_name, emulator=True, just_launch=True)
         strings = ['Project successfully prepared', 'Webpack compilation complete']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text=Changes.JSHelloWord.XML.new_text)
-    
+
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_120_tns_run_ios_just_launch(self):
         """
@@ -426,7 +426,7 @@ class TnsRunJSTests(TnsTest):
         # On some machines it takes time for thr process to die
         time.sleep(7)
         assert not Process.is_running_by_name('node')
-    
+
         # Execute run with --justlaunch again and verify no rebuild is triggered
         result = Tns.run_ios(app_name=self.app_name, emulator=True, just_launch=True)
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.IOS,
@@ -435,18 +435,18 @@ class TnsRunJSTests(TnsTest):
         not_existing_strings = ['Preparing project...', 'Webpack compilation complete.']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_strings)
-    
+
         # Make changes in js, css and xml files
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.JS)
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.XML)
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.CSS)
-    
+
         # Execute run with --justlaunch again and verify prepare is triggered
         result = Tns.run_ios(app_name=self.app_name, emulator=True, just_launch=True)
         strings = ['Project successfully prepared', 'Webpack compilation complete']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.sim.wait_for_text(text=Changes.JSHelloWord.XML.new_text)
-    
+
     @unittest.skip("Skip because of https://github.com/NativeScript/nativescript-cli/issues/4607")
     def test_290_tns_run_android_should_refresh_images(self):
         """
@@ -456,7 +456,7 @@ class TnsRunJSTests(TnsTest):
         source_file = os.path.join(Settings.TEST_RUN_HOME, 'assets', 'issues', 'nativescript-cli-2981', 'main-page.xml')
         dest_file = os.path.join(self.app_path, 'app', 'main-page.xml')
         File.copy(source_file, dest_file)
-    
+
         # Copy image file to app folder
         source_file = os.path.join(Settings.TEST_RUN_HOME, 'assets', 'resources', 'star.png')
         dest_file = os.path.join(self.app_path, 'app', 'test.png')
@@ -467,11 +467,11 @@ class TnsRunJSTests(TnsTest):
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         yellow_count = self.emu.get_pixels_by_color(color=Colors.YELLOW_ICON)
         green_count = self.emu.get_pixels_by_color(color=Colors.GREEN_ICON)
-    
+
         # Verify the referenced image file is displayed on device screen
         assert yellow_count > 0, 'Failed to find yellow color on {0}'.format(self.emu.name)
         assert green_count == 0, 'Found green color on {0}'.format(self.emu.name)
-    
+
         # Change the image file
         source_file = os.path.join(Settings.TEST_RUN_HOME, 'assets', 'resources', 'android',
                                    'drawable-hdpi', 'background.png')
@@ -480,13 +480,13 @@ class TnsRunJSTests(TnsTest):
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID,
                                        run_type=RunType.UNKNOWN, device=self.emu)
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-    
+
         # Verify the new image is synced and displayed on device screen
         yellow_count = self.emu.get_pixels_by_color(color=Colors.YELLOW_ICON)
         green_count = self.emu.get_pixels_by_color(color=Colors.GREEN_ICON)
         assert green_count > 0, 'Failed to find green color on {0}'.format(self.emu.name)
         assert yellow_count == 0, 'Found yellow color on {0}'.format(self.emu.name)
-    
+
     @unittest.skipIf(Settings.HOST_OS == OSType.WINDOWS, 'skip on windows untill we fix wait_rof_log method')
     def test_300_tns_run_android_clean(self):
         """
@@ -494,13 +494,13 @@ class TnsRunJSTests(TnsTest):
         """
         # Run the project once so it is build for the first time
         result = run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, just_launch=True)
-    
+
         # Verify run --clean without changes skip prepare and rebuild of native project
         result = Tns.run_android(app_name=self.app_name, verify=True, device=self.emu.id, clean=True, just_launch=True)
         strings = ['Skipping prepare', 'Building project', 'Gradle clean']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
-    
+
         # Verify if changes are applied and then run with clean it will apply changes on device
         # Verify https://github.com/NativeScript/nativescript-cli/issues/2670 run --clean does
         # clean build only the first time
@@ -511,7 +511,7 @@ class TnsRunJSTests(TnsTest):
         strings.append('Gradle clean')
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text=Changes.JSHelloWord.XML.new_text)
-    
+
         # Make changes again and verify changes are synced and clean build is not triggered again
         Sync.revert(self.app_name, Changes.JSHelloWord.XML)
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID,
@@ -519,7 +519,7 @@ class TnsRunJSTests(TnsTest):
         not_existing_strings = ['Gradle clean']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_strings)
-    
+
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_300_tns_run_ios_clean(self):
         """
@@ -527,13 +527,13 @@ class TnsRunJSTests(TnsTest):
         """
         # Run the project once so it is build for the first time
         result = run_hello_world_js_ts(self.app_name, Platform.IOS, self.sim, just_launch=True)
-    
+
         # Verify run --clean without changes rebuilds native project
         result = Tns.run_ios(app_name=self.app_name, verify=True, device=self.sim.id, clean=True, just_launch=True)
         strings = ['Building project', 'Xcode build...']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.sim.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
-    
+
         # Verify if changes are applied and then run with clean it will apply changes on device
         # Verify https://github.com/NativeScript/nativescript-cli/issues/2670 run --clean does
         # clean build only the first time
@@ -544,7 +544,7 @@ class TnsRunJSTests(TnsTest):
         strings.append('Xcode build...')
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.sim.wait_for_text(text=Changes.JSHelloWord.XML.new_text)
-    
+
         # Make changes again and verify changes are synced and clean build is not triggered again
         Sync.revert(self.app_name, Changes.JSHelloWord.XML)
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.IOS,
@@ -552,7 +552,7 @@ class TnsRunJSTests(TnsTest):
         not_existing_strings = ['Xcode build...']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_strings)
-    
+
     @unittest.skip("Skip because of https://github.com/NativeScript/nativescript-dev-webpack/issues/899")
     def test_310_tns_run_android_sync_changes_in_node_modules(self):
         """
@@ -560,14 +560,14 @@ class TnsRunJSTests(TnsTest):
         """
         # Run the project
         result = run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, sync_all_files=True)
-    
+
         # Make code changes in tns-core-modules verify livesync is triggered
         Sync.replace(self.app_name, Changes.NodeModules.TNS_MODULES)
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID,
                                        run_type=RunType.INCREMENTAL, device=self.emu, file_name='application-common.js')
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
-    
+
     @unittest.skip("Skip because of https://github.com/NativeScript/nativescript-dev-webpack/issues/899")
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_310_tns_run_ios_sync_changes_in_node_modules(self):
@@ -576,14 +576,14 @@ class TnsRunJSTests(TnsTest):
         """
         # Run the project
         result = run_hello_world_js_ts(self.app_name, Platform.IOS, self.sim, sync_all_files=True)
-    
+
         # Make code changes in tns-core-modules verify livesync is triggered
         Sync.replace(self.app_name, Changes.NodeModules.TNS_MODULES)
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID,
                                        run_type=RunType.INCREMENTAL, device=self.emu, file_name='application-common.js')
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
-    
+
     def test_315_tns_run_android_sync_changes_in_aar_files(self):
         """
         Livesync should sync aar file changes inside a plugin
@@ -592,7 +592,7 @@ class TnsRunJSTests(TnsTest):
         # Add plugin and run the project
         Tns.plugin_add('nativescript-camera', self.app_name)
         result = run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, sync_all_files=True)
-    
+
         # Make  changes in nativescript-camera .aar file and  verify livesync is triggered
         new_aar = os.path.join(Settings.TEST_RUN_HOME, 'assets', 'issues', 'nativescript-cli-3932',
                                'nativescript-ui-listview', 'platforms', 'android', 'TNSListView-release.aar')
@@ -602,31 +602,31 @@ class TnsRunJSTests(TnsTest):
                                        run_type=RunType.FULL, device=self.emu)
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
-    
+
     def test_320_tns_run_android_should_warn_if_package_ids_dont_match(self):
         """
         If bundle identifiers in package.json and app.gradle do not match CLI should warn the user.
         """
-    
+
         # Change app id in app.gradle file
         app_gradle = os.path.join(Settings.TEST_RUN_HOME, self.app_name, 'app', 'App_Resources',
                                   'Android', 'app.gradle')
         File.replace(app_gradle, old_string='generatedDensities = []',
                      new_string='applicationId = "org.nativescript.MyApp"')
-    
+
         # Run the app on device and verify the warnings
         result = Tns.run_android(app_name=self.app_name, just_launch=False)
         strings = ["WARNING: The Application identifier is different from the one inside \"package.json\" file.",
                    "NativeScript CLI might not work properly.",
                    "Project successfully built"]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-    
+
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_320_tns_run_ios_should_warn_if_package_ids_dont_match(self):
         """
         If bundle identifiers in package.json and Info.plist do not match CLI should warn the user.
         """
-    
+
         # Change app id in app.gradle file
         old_string = "<string>${EXECUTABLE_NAME}</string>"
         new_string = "<string>${EXECUTABLE_NAME}</string>" \
@@ -635,13 +635,13 @@ class TnsRunJSTests(TnsTest):
         info_plist = os.path.join(Settings.TEST_RUN_HOME, self.app_resources_ios, 'Info.plist')
     
         File.replace(info_plist, old_string, new_string)
-    
+
         # Run the app on device and verify the warnings
         result = Tns.run_ios(app_name=self.app_name, just_launch=False)
         strings = ["[WARNING]: The CFBundleIdentifier key inside the 'Info.plist' will be overriden",
                    "Project successfully built"]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-    
+
     def test_325_tns_run_android_should_start_emulator(self):
         """
         `tns run android` should start emulator if device is not connected.
@@ -657,7 +657,7 @@ class TnsRunJSTests(TnsTest):
             DeviceManager.Emulator.ensure_available(Settings.Emulators.DEFAULT)
         else:
             raise nose.SkipTest('This test is not valid when devices are connected.')
-    
+
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_325_tns_run_ios_should_start_simulator(self):
         """
@@ -675,7 +675,7 @@ class TnsRunJSTests(TnsTest):
             DeviceManager.Simulator.ensure_available(Settings.Simulators.DEFAULT)
         else:
             raise nose.SkipTest('This test is not valid when devices are connected.')
-    
+
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_345_tns_run_ios_source_code_in_ios_part_plugin(self):
         """
@@ -684,19 +684,19 @@ class TnsRunJSTests(TnsTest):
         # Add plugin with source code in iOS part of the plugin
         plugin_path = os.path.join(Settings.TEST_RUN_HOME, 'assets', 'plugins', 'sample-plugin', 'src')
         Tns.plugin_add(plugin_path, path=self.app_name, verify=True)
-    
+
         # Replace main-page.js to call method from the source code of the plugin
         source_js = os.path.join(Settings.TEST_RUN_HOME, 'assets', "issues", 'nativescript-cli-3650',
                                  'main-view-model.js')
         target_js = os.path.join(Settings.TEST_RUN_HOME, self.app_name, 'app', 'main-view-model.js')
         File.copy(source_js, target_js)
-    
+
         result = Tns.run_ios(self.app_name, emulator=True)
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.IOS,
                                        run_type=RunType.FIRST_TIME, device=self.sim)
         strings.append('Hey!')
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-    
+
         # Verify app looks correct inside simulator
         self.sim.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
     
@@ -709,19 +709,19 @@ class TnsRunJSTests(TnsTest):
         source_path = os.path.join(Settings.TEST_RUN_HOME, 'assets', 'issues', 'nativescript-cli-4343', 'src')
         dest_path = os.path.join(self.app_resources_ios, 'src')
         Folder.copy(source_path, dest_path, clean_target=False)
-    
+
         # Replace main-view-model.js to call method from the source code in app resources
         source_js = os.path.join(Settings.TEST_RUN_HOME, 'assets', "issues", 'nativescript-cli-3650',
                                  'main-view-model.js')
         target_js = os.path.join(Settings.TEST_RUN_HOME, self.app_name, 'app', 'main-view-model.js')
         File.copy(source_js, target_js)
-    
+
         result = Tns.run_ios(self.app_name, emulator=True)
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.IOS,
                                        run_type=RunType.FIRST_TIME, device=self.sim)
         strings.append('Hey Native!')
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-    
+
         # Verify app looks correct inside simulator
         self.sim.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
 
@@ -732,11 +732,11 @@ class TnsRunJSTests(TnsTest):
         """
         # Run the project with --justLaunch
         run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, just_launch=True)
-    
+
         # Delete node_modules
         node_modules = os.path.join(Settings.TEST_RUN_HOME, self.app_name, 'node_modules')
         Folder.clean(node_modules)
-    
+
         # Run the project again, verify it is build and node_modules folder exists
         run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, just_launch=True)
         assert Folder.exists(node_modules)
@@ -758,7 +758,7 @@ class TnsRunJSTests(TnsTest):
         """
         # Deploy the app to make sure we have something at /data/data/org.nativescript.TestApp
         result = run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, just_launch=True)
-    
+
         # Use all the disk space on emulator
         for index in range(1, 3000):
             command = "shell cp -r /data/data/org.nativescript.TestApp /data/data/org.nativescript.TestApp" + str(index)
@@ -766,10 +766,10 @@ class TnsRunJSTests(TnsTest):
             Log.info(result.output)
             if "No space left on device" in result.output:
                 break
-    
+
         # Create new app
         Tns.create(app_name='TestApp2', template=Template.HELLO_WORLD_JS.local_package, update=False)
-    
+
         # Run the app and verify there is appropriate error
         result = Tns.run_android('TestApp2', verify=True, device=self.emu.id, just_launch=True)
         strings = ['No space left on device']

--- a/tests/cli/run/tests/run_tests.py
+++ b/tests/cli/run/tests/run_tests.py
@@ -390,7 +390,7 @@ class TnsRunJSTests(TnsTest):
         # Run app with --justlaunch and verify on device
         result = run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, just_launch=True)
         # On some machines it takes time for thr process to die
-        time.sleep(5)
+        time.sleep(10)
         assert not Process.is_running_by_name('node')
 
         # Execute run with --justlaunch again and verify no rebuild is triggered
@@ -424,7 +424,7 @@ class TnsRunJSTests(TnsTest):
         # Run app with --justlaunch and verify on device
         result = run_hello_world_js_ts(self.app_name, Platform.IOS, self.sim, just_launch=True)
         # On some machines it takes time for thr process to die
-        time.sleep(7)
+        time.sleep(10)
         assert not Process.is_running_by_name('node')
 
         # Execute run with --justlaunch again and verify no rebuild is triggered

--- a/tests/cli/run/tests/run_tests.py
+++ b/tests/cli/run/tests/run_tests.py
@@ -22,7 +22,7 @@ from products.nativescript.tns_paths import TnsPaths
 
 class TnsRunJSTests(TnsRunTest):
     app_name = Settings.AppName.DEFAULT
-    app_name_space =Settings.AppName.WITH_SPACE
+    app_name_space = Settings.AppName.WITH_SPACE
     app_path = TnsPaths.get_app_path(app_name)
     app_resources_path = TnsPaths.get_path_app_resources(app_name)
     source_project_dir = TnsPaths.get_app_path(app_name)
@@ -661,7 +661,7 @@ class TnsRunJSTests(TnsRunTest):
             DeviceManager.Simulator.stop()
             result = Tns.run_ios(self.app_name)
             strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.IOS,
-                                       run_type=RunType.FULL, device=self.sim)
+                                           run_type=RunType.FULL, device=self.sim)
             TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=120)
             DeviceManager.Simulator.stop()
             DeviceManager.Simulator.ensure_available(Settings.Simulators.DEFAULT)
@@ -703,7 +703,8 @@ class TnsRunJSTests(TnsRunTest):
         Tns.plugin_add(plugin_path, path=self.app_name, verify=True)
 
         # Replace main-page.js to call method from the source code of the plugin
-        source_js = os.path.join(Settings.TEST_RUN_HOME, 'assets', "issues", 'nativescript-cli-3650', 'main-view-model.js')
+        source_js = os.path.join(Settings.TEST_RUN_HOME, 'assets', "issues", 'nativescript-cli-3650',
+                                 'main-view-model.js')
         target_js = os.path.join(Settings.TEST_RUN_HOME, self.app_name, 'app', 'main-view-model.js')
         File.copy(source_js, target_js)
 
@@ -725,9 +726,10 @@ class TnsRunJSTests(TnsRunTest):
         source_path = os.path.join(Settings.TEST_RUN_HOME, 'assets', 'issues', 'nativescript-cli-4343', 'src')
         dest_path = os.path.join(self.app_resources_ios, 'src')
         Folder.copy(source_path, dest_path, clean_target=False)
-        
+
         # Replace main-view-model.js to call method from the source code in app resources
-        source_js = os.path.join(Settings.TEST_RUN_HOME, 'assets', "issues", 'nativescript-cli-3650', 'main-view-model.js')
+        source_js = os.path.join(Settings.TEST_RUN_HOME, 'assets', "issues", 'nativescript-cli-3650',
+                                 'main-view-model.js')
         target_js = os.path.join(Settings.TEST_RUN_HOME, self.app_name, 'app', 'main-view-model.js')
         File.copy(source_js, target_js)
 
@@ -747,7 +749,7 @@ class TnsRunJSTests(TnsRunTest):
         """
         # Run the project with --justLaunch
         run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, just_launch=True)
-        
+
         # Delete node_modules
         node_modules = os.path.join(Settings.TEST_RUN_HOME, self.app_name, 'node_modules')
         Folder.clean(node_modules)

--- a/tests/cli/run/tests/run_tests.py
+++ b/tests/cli/run/tests/run_tests.py
@@ -438,7 +438,6 @@ class TnsRunJSTests(TnsRunTest):
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.sim.wait_for_text(text=Changes.JSHelloWord.XML.new_text)
 
-
     @unittest.skip("Skip because of https://github.com/NativeScript/nativescript-cli/issues/4607")
     def test_290_tns_run_android_should_refresh_images(self):
         """
@@ -622,8 +621,8 @@ class TnsRunJSTests(TnsRunTest):
         # Change app id in app.gradle file
         old_string = "<string>${EXECUTABLE_NAME}</string>"
         new_string = "<string>${EXECUTABLE_NAME}</string>" \
-               "<key>CFBundleIdentifier</key>" \
-               "<string>org.nativescript.myapp</string>"
+                     "<key>CFBundleIdentifier</key>" \
+                     "<string>org.nativescript.myapp</string>"
         info_plist = os.path.join(Settings.TEST_RUN_HOME, self.app_resources_ios, 'Info.plist')
 
         File.replace(info_plist, old_string, new_string)

--- a/tests/cli/run/tests/run_tests.py
+++ b/tests/cli/run/tests/run_tests.py
@@ -110,7 +110,6 @@ class TnsRunJSTests(TnsRunTest):
         Sync.replace(self.app_name, Changes.JSHelloWord.XML_INVALID)
         strings = ['main-page.xml', 'Error: Parsing XML']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-        self.sim.wait_for_text(text='Exception')
 
         # Revert changes
         Sync.revert(self.app_name, Changes.JSHelloWord.XML_INVALID)
@@ -119,26 +118,6 @@ class TnsRunJSTests(TnsRunTest):
         strings = ['Successfully synced application']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.sim.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
-        assert not self.sim.is_text_visible(text='Exception')
-
-        # Delete app.js and verify app crash with error activity dialog
-        app_js_origin_path = os.path.join(self.source_project_dir, 'app', 'app.js')
-        app_js_backup_path = os.path.join(self.target_project_dir, 'app', 'app.js')
-        File.delete(app_js_origin_path)
-
-        # Verify app is synced
-        strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID,
-                                       device=self.sim, run_type=RunType.UNKNOWN)
-        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-        self.sim.wait_for_text(text='Exception')
-
-        # Restore app.js and verify app is synced and recovered
-        File.copy(app_js_backup_path, app_js_origin_path)
-        strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID,
-                                       run_type=RunType.UNKNOWN, device=self.emu)
-        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-        self.sim.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
-        assert not self.sim.is_text_visible(text='Exception')
 
     @unittest.skipIf(Settings.HOST_OS == OSType.WINDOWS, 'skip on windows untill we fix wait_rof_log method')
     def test_105_tns_run_android_changes_in_app_resounces(self):
@@ -183,6 +162,49 @@ class TnsRunJSTests(TnsRunTest):
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_strings)
 
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_105_tns_run_ios_changes_in_app_resounces(self):
+        """
+            Make changes in AndroidManifest.xml in App_Resources and verify this triggers rebuild of the app.
+            Verify that when run on android changes in AppResources/iOS do not trigger rebuild
+        """
+        # Run app and verify on device
+        result = run_hello_world_js_ts(self.app_name, Platform.IOS, self.sim)
+
+        # Make changes in app resources, add aditional icon
+        File.copy(os.path.join(Settings.TEST_RUN_HOME, 'assets', 'resources', 'ios', 'Default.png'),
+                  os.path.join(self.app_resources_ios, 'Assets.xcassets', 'icon.png'))
+
+        # Verify rebuild is triggered and app is synced
+        strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.IOS,
+                                       run_type=RunType.FULL, device=self.sim)
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+        self.sim.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
+        self.sim.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
+
+        # Make changes in AppResources/IOS
+        File.copy(os.path.join(os.path.join(Settings.TEST_RUN_HOME, 'assets', 'resources', 'ios', 'Default.png')),
+                  os.path.join(self.app_resources_ios, 'Assets.xcassets', 'AppIcon.appiconset', 'icon-20.png'))
+        # Verify only build for ios is triggered
+        strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.IOS,
+                                       run_type=RunType.FULL, device=self.sim)
+        not_existing_strings = ['Gradle build']
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
+                             not_existing_string_list=not_existing_strings)
+
+        # https://github.com/NativeScript/nativescript-cli/issues/3658
+        Tns.kill()
+        # Make changes in AppResources/Android
+        File.copy(os.path.join(Settings.TEST_RUN_HOME, 'assets', 'resources', 'android', 'drawable-hdpi', 'icon.png'),
+                  os.path.join(self.app_resources_android, 'src', 'main', 'res', 'drawable-hdpi', 'icon.png'))
+        result = Tns.run_ios(app_name=self.app_name, device=self.sim.id)
+        strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.IOS,
+                                       run_type=RunType.UNKNOWN, device=self.sim)
+        # Verify no build is triggered
+        not_existing_strings = ['Xcode build', 'Gradle build']
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
+                             not_existing_string_list=not_existing_strings)
+
     def test_110_tns_run_android_release(self):
         # Run app and verify on device
         result = Tns.run_android(app_name=self.app_name, release=True, verify=True, emulator=True)
@@ -210,6 +232,32 @@ class TnsRunJSTests(TnsRunTest):
         self.emu.wait_for_text(text=Changes.JSHelloWord.JS.new_text)
         self.emu.wait_for_text(text=Changes.JSHelloWord.XML.new_text)
         self.emu.wait_for_color(color=Colors.LIGHT_BLUE, pixel_count=blue_count * 2, delta=25)
+
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_110_tns_run_ios_release(self):
+        # Run app and verify on device
+        result = Tns.run_ios(app_name=self.app_name, release=True, verify=True, emulator=True)
+        strings = ['Webpack compilation complete', 'Project successfully built', 'Successfully started on device']
+        # Verify console logs are not displayed in release builds
+        not_existing_strings = ['JS:']
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
+                             not_existing_string_list=not_existing_strings)
+        self.sim.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
+        self.sim.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
+        blue_count = self.sim.get_pixels_by_color(color=Colors.LIGHT_BLUE)
+        assert blue_count > 100, 'Failed to find blue color on {0}'.format(self.sim.name)
+
+        Tns.kill()
+        # Make changes in js, css and xml files
+        Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.JS)
+        Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.XML)
+        Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.CSS)
+
+        # Run with --release again and verify changes are deployed on device
+        result = Tns.run_ios(app_name=self.app_name, release=True, verify=True, emulator=True)
+        self.sim.wait_for_text(text=Changes.JSHelloWord.JS.new_text)
+        self.sim.wait_for_text(text=Changes.JSHelloWord.XML.new_text)
+        self.sim.wait_for_color(color=Colors.LIGHT_BLUE, pixel_count=blue_count * 2, delta=25)
 
     @unittest.skipIf(Settings.HOST_OS == OSType.WINDOWS, 'skip on windows untill we fix wait_rof_log method')
     def test_115_tns_run_android_add_remove_files_and_folders(self):
@@ -267,6 +315,61 @@ class TnsRunJSTests(TnsRunTest):
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text='Exception')
 
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_115_tns_run_ios_add_remove_files_and_folders(self):
+        """
+        Add/delete files and folders should be synced properly
+        """
+        # Run app and verify on device
+        result = run_hello_world_js_ts(self.app_name, Platform.IOS, self.sim)
+
+        # Add new file
+        # To verify that file is synced on device we have to refer some function
+        # from it and verify it is executed. We will use console.log
+        app_folder = os.path.join(self.source_project_dir, 'app')
+        new_file = os.path.join(app_folder, 'test.js')
+        renamed_file = os.path.join(app_folder, 'test_2.js')
+        app_js_file = os.path.join(app_folder, 'main-view-model.js')
+        File.write(new_file, "console.log('test.js synced!!!');")
+        File.append(app_js_file, "require('./test.js');")
+        strings = ["test.js synced!!!"]
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+
+        # Rename file
+        os.rename(new_file, renamed_file)
+        File.replace(renamed_file, 'test.js', 'renamed file')
+        File.replace(app_js_file, 'test.js', 'test_2.js')
+        strings = ["renamed file synced!!!"]
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+
+        # Delete file
+        File.delete(renamed_file)
+        strings = ["Module build failed: Error: ENOENT"]
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+
+        File.replace(app_js_file, "require('./test_2.js');", ' ')
+        strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.IOS,
+                                       device=self.sim, run_type=RunType.UNKNOWN)
+        not_existing_strings = ['Error']
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
+                             not_existing_string_list=not_existing_strings)
+        self.sim.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
+
+        # Add folder
+        folder_name = os.path.join(app_folder, 'test_folder')
+        new_file = os.path.join(folder_name, 'test_in_folder.js')
+        Folder.create(folder_name)
+        File.write(new_file, "console.log('test_in_folder.js synced!!!');")
+        File.append(app_js_file, "require('./test_folder/test_in_folder.js');")
+        strings = ["test_in_folder.js synced!!!"]
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+        self.sim.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
+
+        # Delete folder
+        Folder.clean(folder_name)
+        strings = ["Module build failed: Error: ENOENT"]
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+
     def test_120_tns_run_android_just_launch(self):
         """
         This test verify following things:
@@ -299,6 +402,41 @@ class TnsRunJSTests(TnsRunTest):
         strings = ['Project successfully prepared', 'Webpack compilation complete']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text=Changes.JSHelloWord.XML.new_text)
+
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_120_tns_run_ios_just_launch(self):
+        """
+        This test verify following things:
+        1. `--justlaunch` option release the console.
+        2. Full rebuild and prepare are not trigerred if no changes are done.
+        3. Incremental prepare is triggered if js, xml and css files are changed.
+        """
+        # Run app with --justlaunch and verify on device
+        result = run_hello_world_js_ts(self.app_name, Platform.IOS, self.sim, just_launch=True)
+        # On some machines it takes time for thr process to die
+        time.sleep(5)
+        assert not Process.is_running_by_name('node')
+
+        # Execute run with --justlaunch again and verify no rebuild is triggered
+        result = Tns.run_ios(app_name=self.app_name, emulator=True, just_launch=True)
+        strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.IOS,
+                                       run_type=RunType.INCREMENTAL, device=self.sim, just_launch=True)
+        strings.remove('Refreshing application on device')
+        not_existing_strings = ['Preparing project...', 'Webpack compilation complete.']
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
+                             not_existing_string_list=not_existing_strings)
+
+        # Make changes in js, css and xml files
+        Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.JS)
+        Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.XML)
+        Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.CSS)
+
+        # Execute run with --justlaunch again and verify prepare is triggered
+        result = Tns.run_ios(app_name=self.app_name, emulator=True, just_launch=True)
+        strings = ['Project successfully prepared', 'Webpack compilation complete']
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+        self.sim.wait_for_text(text=Changes.JSHelloWord.XML.new_text)
+
 
     @unittest.skip("Skip because of https://github.com/NativeScript/nativescript-cli/issues/4607")
     def test_290_tns_run_android_should_refresh_images(self):
@@ -369,6 +507,39 @@ class TnsRunJSTests(TnsRunTest):
         Sync.revert(self.app_name, Changes.JSHelloWord.XML)
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID,
                                        run_type=RunType.INCREMENTAL, device=self.emu, file_name='main-page.xml')
+        not_existing_strings = ['Gradle clean']
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
+                             not_existing_string_list=not_existing_strings)
+
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_300_tns_run_ios_clean(self):
+        """
+        If  set --clean rebuilds the native project
+        """
+        # Run the project once so it is build for the first time
+        result = run_hello_world_js_ts(self.app_name, Platform.IOS, self.sim, just_launch=True)
+
+        # Verify run --clean without changes skip prepare and rebuild of native project
+        result = Tns.run_ios(app_name=self.app_name, verify=True, device=self.sim.id, clean=True, just_launch=True)
+        strings = ['Skipping prepare', 'Building project', 'Gradle clean']
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+        self.sim.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
+
+        # Verify if changes are applied and then run with clean it will apply changes on device
+        # Verify https://github.com/NativeScript/nativescript-cli/issues/2670 run --clean does
+        # clean build only the first time
+        Sync.replace(self.app_name, Changes.JSHelloWord.XML)
+        result = Tns.run_ios(app_name=self.app_name, verify=True, device=self.sim.id, clean=True)
+        strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.IOS,
+                                       run_type=RunType.FULL, device=self.sim)
+        strings.append('Gradle clean')
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+        self.emu.wait_for_text(text=Changes.JSHelloWord.XML.new_text)
+
+        # Make changes again and verify changes are synced and clean build is not triggered again
+        Sync.revert(self.app_name, Changes.JSHelloWord.XML)
+        strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.IOS,
+                                       run_type=RunType.INCREMENTAL, device=self.sim, file_name='main-page.xml')
         not_existing_strings = ['Gradle clean']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_strings)

--- a/tests/cli/run/tests/run_tests.py
+++ b/tests/cli/run/tests/run_tests.py
@@ -63,33 +63,33 @@ class TnsRunJSTests(TnsRunTest):
         """
         # Run app and verify on device
         result = run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu)
-
+    
         # Make changes in xml that will break the app
         Sync.replace(self.app_name, Changes.JSHelloWord.XML_INVALID)
         strings = ['main-page.xml', 'Error: Parsing XML']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text='Exception')
-
+    
         # Revert changes
         Sync.revert(self.app_name, Changes.JSHelloWord.XML_INVALID)
-
+    
         # Verify app is synced and recovered
         strings = ['Successfully synced application']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
         assert not self.emu.is_text_visible(text='Exception')
-
+    
         # Delete app.js and verify app crash with error activity dialog
         app_js_origin_path = os.path.join(self.source_project_dir, 'app', 'app.js')
         app_js_backup_path = os.path.join(self.target_project_dir, 'app', 'app.js')
         File.delete(app_js_origin_path)
-
+    
         # Verify app is synced
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID,
                                        device=self.emu, run_type=RunType.UNKNOWN)
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text='Exception')
-
+    
         # Restore app.js and verify app is synced and recovered
         File.copy(app_js_backup_path, app_js_origin_path)
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID,
@@ -97,7 +97,7 @@ class TnsRunJSTests(TnsRunTest):
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
         assert not self.emu.is_text_visible(text='Exception')
-
+    
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_100_run_ios_break_and_fix_app(self):
         """
@@ -106,20 +106,20 @@ class TnsRunJSTests(TnsRunTest):
         """
         # Run app and verify on device
         result = run_hello_world_js_ts(self.app_name, Platform.IOS, self.sim)
-
+    
         # Make changes in xml that will break the app
         Sync.replace(self.app_name, Changes.JSHelloWord.XML_INVALID)
         strings = ['main-page.xml', 'Error: Parsing XML']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-
+    
         # Revert changes
         Sync.revert(self.app_name, Changes.JSHelloWord.XML_INVALID)
-
+    
         # Verify app is synced and recovered
         strings = ['Successfully synced application']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.sim.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
-
+    
     @unittest.skipIf(Settings.HOST_OS == OSType.WINDOWS, 'skip on windows untill we fix wait_rof_log method')
     def test_105_tns_run_android_changes_in_app_resounces(self):
         """
@@ -128,18 +128,18 @@ class TnsRunJSTests(TnsRunTest):
         """
         # Run app and verify on device
         result = run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu)
-
+    
         # Make changes in AndroidManifest.xml
         manifest_path = os.path.join(self.app_resources_android, 'src', 'main', 'AndroidManifest.xml')
         File.replace(manifest_path, 'largeScreens="true"', 'largeScreens="false"')
-
+    
         # Verify rebuild is triggered and app is synced
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID,
                                        run_type=RunType.FULL, device=self.emu)
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
         self.emu.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
-
+    
         # Make changes in AppResources/Android
         File.copy(os.path.join(Settings.TEST_RUN_HOME, 'assets', 'resources', 'android', 'drawable-hdpi', 'icon.png'),
                   os.path.join(self.app_resources_android, 'src', 'main', 'res', 'drawable-hdpi', 'icon.png'))
@@ -149,7 +149,7 @@ class TnsRunJSTests(TnsRunTest):
         not_existing_strings = ['Xcode build']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_strings)
-
+    
         # https://github.com/NativeScript/nativescript-cli/issues/3658
         Tns.kill()
         # Make changes in AppResources/iOS
@@ -162,7 +162,7 @@ class TnsRunJSTests(TnsRunTest):
         not_existing_strings = ['Xcode build', 'Gradle build']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_strings)
-
+    
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_105_tns_run_ios_changes_in_app_resounces(self):
         """
@@ -171,18 +171,18 @@ class TnsRunJSTests(TnsRunTest):
         """
         # Run app and verify on device
         result = run_hello_world_js_ts(self.app_name, Platform.IOS, self.sim)
-
+    
         # Make changes in app resources, add aditional icon
         File.copy(os.path.join(Settings.TEST_RUN_HOME, 'assets', 'resources', 'ios', 'Default.png'),
                   os.path.join(self.app_resources_ios, 'Assets.xcassets', 'icon.png'))
-
+    
         # Verify rebuild is triggered and app is synced
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.IOS,
                                        run_type=RunType.FULL, device=self.sim)
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.sim.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
         self.sim.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
-
+    
         # Make changes in AppResources/IOS
         File.copy(os.path.join(os.path.join(Settings.TEST_RUN_HOME, 'assets', 'resources', 'ios', 'Default.png')),
                   os.path.join(self.app_resources_ios, 'Assets.xcassets', 'AppIcon.appiconset', 'icon-20.png'))
@@ -192,7 +192,7 @@ class TnsRunJSTests(TnsRunTest):
         not_existing_strings = ['Gradle build']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_strings)
-
+    
         # https://github.com/NativeScript/nativescript-cli/issues/3658
         Tns.kill()
         # Make changes in AppResources/Android
@@ -205,7 +205,7 @@ class TnsRunJSTests(TnsRunTest):
         not_existing_strings = ['Xcode build', 'Gradle build']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_strings)
-
+    
     def test_110_tns_run_android_release(self):
         # Run app and verify on device
         result = Tns.run_android(app_name=self.app_name, release=True, verify=True, emulator=True)
@@ -221,19 +221,19 @@ class TnsRunJSTests(TnsRunTest):
         self.emu.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
         blue_count = self.emu.get_pixels_by_color(color=Colors.LIGHT_BLUE)
         assert blue_count > 100, 'Failed to find blue color on {0}'.format(self.emu.name)
-
+    
         Tns.kill()
         # Make changes in js, css and xml files
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.JS)
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.XML)
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.CSS)
-
+    
         # Run with --release again and verify changes are deployed on device
         result = Tns.run_android(app_name=self.app_name, release=True, verify=True, emulator=True)
         self.emu.wait_for_text(text=Changes.JSHelloWord.JS.new_text)
         self.emu.wait_for_text(text=Changes.JSHelloWord.XML.new_text)
         self.emu.wait_for_color(color=Colors.LIGHT_BLUE, pixel_count=blue_count * 2, delta=25)
-
+    
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_110_tns_run_ios_release(self):
         # Run app and verify on device
@@ -247,19 +247,19 @@ class TnsRunJSTests(TnsRunTest):
         self.sim.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
         blue_count = self.sim.get_pixels_by_color(color=Colors.LIGHT_BLUE)
         assert blue_count > 100, 'Failed to find blue color on {0}'.format(self.sim.name)
-
+    
         Tns.kill()
         # Make changes in js, css and xml files
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.JS)
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.XML)
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.CSS)
-
+    
         # Run with --release again and verify changes are deployed on device
         result = Tns.run_ios(app_name=self.app_name, release=True, verify=True, emulator=True)
         self.sim.wait_for_text(text=Changes.JSHelloWord.JS.new_text)
         self.sim.wait_for_text(text=Changes.JSHelloWord.XML.new_text)
         self.sim.wait_for_color(color=Colors.LIGHT_BLUE, pixel_count=blue_count * 2, delta=25)
-
+    
     @unittest.skipIf(Settings.HOST_OS == OSType.WINDOWS, 'skip on windows untill we fix wait_rof_log method')
     def test_115_tns_run_android_add_remove_files_and_folders(self):
         """
@@ -267,7 +267,7 @@ class TnsRunJSTests(TnsRunTest):
         """
         # Run app and verify on device
         result = run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu)
-
+    
         # Add new file
         # To verify that file is synced on device we have to refer some function
         # from it and verify it is executed. We will use console.log
@@ -279,20 +279,20 @@ class TnsRunJSTests(TnsRunTest):
         File.append(app_js_file, "require('./test.js');")
         strings = ["JS: test.js synced!!!"]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-
+    
         # Rename file
         os.rename(new_file, renamed_file)
         File.replace(renamed_file, 'test.js', 'renamed file')
         File.replace(app_js_file, 'test.js', 'test_2.js')
         strings = ["JS: renamed file synced!!!"]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-
+    
         # Delete file
         File.delete(renamed_file)
         strings = ["Module build failed: Error: ENOENT", 'Successfully synced application']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text='Exception')
-
+    
         File.replace(app_js_file, "require('./test_2.js');", ' ')
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID,
                                        device=self.emu, run_type=RunType.UNKNOWN)
@@ -300,7 +300,7 @@ class TnsRunJSTests(TnsRunTest):
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_strings)
         self.emu.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
-
+    
         # Add folder
         folder_name = os.path.join(app_folder, 'test_folder')
         new_file = os.path.join(folder_name, 'test_in_folder.js')
@@ -309,13 +309,13 @@ class TnsRunJSTests(TnsRunTest):
         File.append(app_js_file, "require('./test_folder/test_in_folder.js');")
         strings = ["JS: test_in_folder.js synced!!!"]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-
+    
         # Delete folder
         Folder.clean(folder_name)
         strings = ["Module build failed: Error: ENOENT"]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text='Exception')
-
+    
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_115_tns_run_ios_add_remove_files_and_folders(self):
         """
@@ -323,7 +323,7 @@ class TnsRunJSTests(TnsRunTest):
         """
         # Run app and verify on device
         result = run_hello_world_js_ts(self.app_name, Platform.IOS, self.sim)
-
+    
         # Add new file
         # To verify that file is synced on device we have to refer some function
         # from it and verify it is executed. We will use console.log
@@ -335,19 +335,19 @@ class TnsRunJSTests(TnsRunTest):
         File.append(app_js_file, "require('./test.js');")
         strings = ["test.js synced!!!"]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-
+    
         # Rename file
         os.rename(new_file, renamed_file)
         File.replace(renamed_file, 'test.js', 'renamed file')
         File.replace(app_js_file, 'test.js', 'test_2.js')
         strings = ["renamed file synced!!!"]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-
+    
         # Delete file
         File.delete(renamed_file)
         strings = ["Module build failed: Error: ENOENT", "NativeScript debugger detached"]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-
+    
         File.replace(app_js_file, "require('./test_2.js');", ' ')
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.IOS,
                                        device=self.sim, run_type=RunType.UNKNOWN)
@@ -355,7 +355,7 @@ class TnsRunJSTests(TnsRunTest):
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_strings)
         self.sim.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
-
+    
         # Add folder
         folder_name = os.path.join(app_folder, 'test_folder')
         new_file = os.path.join(folder_name, 'test_in_folder.js')
@@ -365,12 +365,12 @@ class TnsRunJSTests(TnsRunTest):
         strings = ["test_in_folder.js synced!!!"]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.sim.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
-
+    
         # Delete folder
         Folder.clean(folder_name)
         strings = ["Module build failed: Error: ENOENT"]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-
+    
     def test_120_tns_run_android_just_launch(self):
         """
         This test verify following things:
@@ -383,7 +383,7 @@ class TnsRunJSTests(TnsRunTest):
         # On some machines it takes time for thr process to die
         time.sleep(5)
         assert not Process.is_running_by_name('node')
-
+    
         # Execute run with --justlaunch again and verify no rebuild is triggered
         result = Tns.run_android(app_name=self.app_name, emulator=True, just_launch=True)
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID,
@@ -392,18 +392,18 @@ class TnsRunJSTests(TnsRunTest):
         not_existing_strings = ['Preparing project...', 'Webpack compilation complete.']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_strings)
-
+    
         # Make changes in js, css and xml files
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.JS)
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.XML)
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.CSS)
-
+    
         # Execute run with --justlaunch again and verify prepare is triggered
         result = Tns.run_android(app_name=self.app_name, emulator=True, just_launch=True)
         strings = ['Project successfully prepared', 'Webpack compilation complete']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text=Changes.JSHelloWord.XML.new_text)
-
+    
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_120_tns_run_ios_just_launch(self):
         """
@@ -417,7 +417,7 @@ class TnsRunJSTests(TnsRunTest):
         # On some machines it takes time for thr process to die
         time.sleep(5)
         assert not Process.is_running_by_name('node')
-
+    
         # Execute run with --justlaunch again and verify no rebuild is triggered
         result = Tns.run_ios(app_name=self.app_name, emulator=True, just_launch=True)
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.IOS,
@@ -426,18 +426,18 @@ class TnsRunJSTests(TnsRunTest):
         not_existing_strings = ['Preparing project...', 'Webpack compilation complete.']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_strings)
-
+    
         # Make changes in js, css and xml files
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.JS)
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.XML)
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.CSS)
-
+    
         # Execute run with --justlaunch again and verify prepare is triggered
         result = Tns.run_ios(app_name=self.app_name, emulator=True, just_launch=True)
         strings = ['Project successfully prepared', 'Webpack compilation complete']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.sim.wait_for_text(text=Changes.JSHelloWord.XML.new_text)
-
+    
     @unittest.skip("Skip because of https://github.com/NativeScript/nativescript-cli/issues/4607")
     def test_290_tns_run_android_should_refresh_images(self):
         """
@@ -447,7 +447,7 @@ class TnsRunJSTests(TnsRunTest):
         source_file = os.path.join(Settings.TEST_RUN_HOME, 'assets', 'issues', 'nativescript-cli-2981', 'main-page.xml')
         dest_file = os.path.join(self.app_path, 'app', 'main-page.xml')
         File.copy(source_file, dest_file)
-
+    
         # Copy image file to app folder
         source_file = os.path.join(Settings.TEST_RUN_HOME, 'assets', 'resources', 'star.png')
         dest_file = os.path.join(self.app_path, 'app', 'test.png')
@@ -458,11 +458,11 @@ class TnsRunJSTests(TnsRunTest):
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         yellow_count = self.emu.get_pixels_by_color(color=Colors.YELLOW_ICON)
         green_count = self.emu.get_pixels_by_color(color=Colors.GREEN_ICON)
-
+    
         # Verify the referenced image file is displayed on device screen
         assert yellow_count > 0, 'Failed to find yellow color on {0}'.format(self.emu.name)
         assert green_count == 0, 'Found green color on {0}'.format(self.emu.name)
-
+    
         # Change the image file
         source_file = os.path.join(Settings.TEST_RUN_HOME, 'assets', 'resources', 'android',
                                    'drawable-hdpi', 'background.png')
@@ -471,13 +471,13 @@ class TnsRunJSTests(TnsRunTest):
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID,
                                        run_type=RunType.UNKNOWN, device=self.emu)
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-
+    
         # Verify the new image is synced and displayed on device screen
         yellow_count = self.emu.get_pixels_by_color(color=Colors.YELLOW_ICON)
         green_count = self.emu.get_pixels_by_color(color=Colors.GREEN_ICON)
         assert green_count > 0, 'Failed to find green color on {0}'.format(self.emu.name)
         assert yellow_count == 0, 'Found yellow color on {0}'.format(self.emu.name)
-
+    
     @unittest.skipIf(Settings.HOST_OS == OSType.WINDOWS, 'skip on windows untill we fix wait_rof_log method')
     def test_300_tns_run_android_clean(self):
         """
@@ -485,13 +485,13 @@ class TnsRunJSTests(TnsRunTest):
         """
         # Run the project once so it is build for the first time
         result = run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, just_launch=True)
-
+    
         # Verify run --clean without changes skip prepare and rebuild of native project
         result = Tns.run_android(app_name=self.app_name, verify=True, device=self.emu.id, clean=True, just_launch=True)
         strings = ['Skipping prepare', 'Building project', 'Gradle clean']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
-
+    
         # Verify if changes are applied and then run with clean it will apply changes on device
         # Verify https://github.com/NativeScript/nativescript-cli/issues/2670 run --clean does
         # clean build only the first time
@@ -502,7 +502,7 @@ class TnsRunJSTests(TnsRunTest):
         strings.append('Gradle clean')
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text=Changes.JSHelloWord.XML.new_text)
-
+    
         # Make changes again and verify changes are synced and clean build is not triggered again
         Sync.revert(self.app_name, Changes.JSHelloWord.XML)
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID,
@@ -510,7 +510,7 @@ class TnsRunJSTests(TnsRunTest):
         not_existing_strings = ['Gradle clean']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_strings)
-
+    
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_300_tns_run_ios_clean(self):
         """
@@ -518,13 +518,13 @@ class TnsRunJSTests(TnsRunTest):
         """
         # Run the project once so it is build for the first time
         result = run_hello_world_js_ts(self.app_name, Platform.IOS, self.sim, just_launch=True)
-
+    
         # Verify run --clean without changes rebuilds native project
         result = Tns.run_ios(app_name=self.app_name, verify=True, device=self.sim.id, clean=True, just_launch=True)
         strings = ['Building project', 'Xcode build...']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.sim.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
-
+    
         # Verify if changes are applied and then run with clean it will apply changes on device
         # Verify https://github.com/NativeScript/nativescript-cli/issues/2670 run --clean does
         # clean build only the first time
@@ -535,7 +535,7 @@ class TnsRunJSTests(TnsRunTest):
         strings.append('Xcode build...')
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.sim.wait_for_text(text=Changes.JSHelloWord.XML.new_text)
-
+    
         # Make changes again and verify changes are synced and clean build is not triggered again
         Sync.revert(self.app_name, Changes.JSHelloWord.XML)
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.IOS,
@@ -543,7 +543,7 @@ class TnsRunJSTests(TnsRunTest):
         not_existing_strings = ['Xcode build...']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_strings)
-
+    
     @unittest.skip("Skip because of https://github.com/NativeScript/nativescript-dev-webpack/issues/899")
     def test_310_tns_run_android_sync_changes_in_node_modules(self):
         """
@@ -551,14 +551,14 @@ class TnsRunJSTests(TnsRunTest):
         """
         # Run the project
         result = run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, sync_all_files=True)
-
+    
         # Make code changes in tns-core-modules verify livesync is triggered
         Sync.replace(self.app_name, Changes.NodeModules.TNS_MODULES)
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID,
                                        run_type=RunType.INCREMENTAL, device=self.emu, file_name='application-common.js')
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
-
+    
     @unittest.skip("Skip because of https://github.com/NativeScript/nativescript-dev-webpack/issues/899")
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_310_tns_run_ios_sync_changes_in_node_modules(self):
@@ -567,14 +567,14 @@ class TnsRunJSTests(TnsRunTest):
         """
         # Run the project
         result = run_hello_world_js_ts(self.app_name, Platform.IOS, self.sim, sync_all_files=True)
-
+    
         # Make code changes in tns-core-modules verify livesync is triggered
         Sync.replace(self.app_name, Changes.NodeModules.TNS_MODULES)
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID,
                                        run_type=RunType.INCREMENTAL, device=self.emu, file_name='application-common.js')
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
-
+    
     def test_315_tns_run_android_sync_changes_in_aar_files(self):
         """
         Livesync should sync aar file changes inside a plugin
@@ -583,7 +583,7 @@ class TnsRunJSTests(TnsRunTest):
         # Add plugin and run the project
         Tns.plugin_add('nativescript-camera', self.app_name)
         result = run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, sync_all_files=True)
-
+    
         # Make  changes in nativescript-camera .aar file and  verify livesync is triggered
         new_aar = os.path.join(Settings.TEST_RUN_HOME, 'assets', 'issues', 'nativescript-cli-3932',
                                'nativescript-ui-listview', 'platforms', 'android', 'TNSListView-release.aar')
@@ -593,46 +593,46 @@ class TnsRunJSTests(TnsRunTest):
                                        run_type=RunType.FULL, device=self.emu)
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
-
+    
     def test_320_tns_run_android_should_warn_if_package_ids_dont_match(self):
         """
         If bundle identifiers in package.json and app.gradle do not match CLI should warn the user.
         """
-
+    
         # Change app id in app.gradle file
         app_gradle = os.path.join(Settings.TEST_RUN_HOME, self.app_name, 'app', 'App_Resources',
                                   'Android', 'app.gradle')
         File.replace(app_gradle, old_string='generatedDensities = []',
                      new_string='applicationId = "org.nativescript.MyApp"')
-
+    
         # Run the app on device and verify the warnings
         result = Tns.run_android(app_name=self.app_name, just_launch=False)
         strings = ["WARNING: The Application identifier is different from the one inside \"package.json\" file.",
                    "NativeScript CLI might not work properly.",
                    "Project successfully built"]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-
+    
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_320_tns_run_ios_should_warn_if_package_ids_dont_match(self):
         """
         If bundle identifiers in package.json and Info.plist do not match CLI should warn the user.
         """
-
+    
         # Change app id in app.gradle file
         old_string = "<string>${EXECUTABLE_NAME}</string>"
         new_string = "<string>${EXECUTABLE_NAME}</string>" \
                      "<key>CFBundleIdentifier</key>" \
                      "<string>org.nativescript.myapp</string>"
         info_plist = os.path.join(Settings.TEST_RUN_HOME, self.app_resources_ios, 'Info.plist')
-
+    
         File.replace(info_plist, old_string, new_string)
-
+    
         # Run the app on device and verify the warnings
         result = Tns.run_ios(app_name=self.app_name, just_launch=False)
         strings = ["[WARNING]: The CFBundleIdentifier key inside the 'Info.plist' will be overriden",
                    "Project successfully built"]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-
+    
     def test_325_tns_run_android_should_start_emulator(self):
         """
         `tns run android` should start emulator if device is not connected.
@@ -648,7 +648,7 @@ class TnsRunJSTests(TnsRunTest):
             DeviceManager.Emulator.ensure_available(Settings.Emulators.DEFAULT)
         else:
             raise nose.SkipTest('This test is not valid when devices are connected.')
-
+    
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_325_tns_run_ios_should_start_simulator(self):
         """
@@ -666,7 +666,7 @@ class TnsRunJSTests(TnsRunTest):
             DeviceManager.Simulator.ensure_available(Settings.Simulators.DEFAULT)
         else:
             raise nose.SkipTest('This test is not valid when devices are connected.')
-
+    
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_345_tns_run_ios_source_code_in_ios_part_plugin(self):
         """
@@ -675,22 +675,22 @@ class TnsRunJSTests(TnsRunTest):
         # Add plugin with source code in iOS part of the plugin
         plugin_path = os.path.join(Settings.TEST_RUN_HOME, 'assets', 'plugins', 'sample-plugin', 'src')
         Tns.plugin_add(plugin_path, path=self.app_name, verify=True)
-
+    
         # Replace main-page.js to call method from the source code of the plugin
         source_js = os.path.join(Settings.TEST_RUN_HOME, 'assets', "issues", 'nativescript-cli-3650',
                                  'main-view-model.js')
         target_js = os.path.join(Settings.TEST_RUN_HOME, self.app_name, 'app', 'main-view-model.js')
         File.copy(source_js, target_js)
-
+    
         result = Tns.run_ios(self.app_name, emulator=True)
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.IOS,
                                        run_type=RunType.FIRST_TIME, device=self.sim)
         strings.append('Hey!')
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-
+    
         # Verify app looks correct inside simulator
         self.sim.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
-
+    
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_350_tns_run_ios_source_code_in_app_resources(self):
         """
@@ -700,19 +700,19 @@ class TnsRunJSTests(TnsRunTest):
         source_path = os.path.join(Settings.TEST_RUN_HOME, 'assets', 'issues', 'nativescript-cli-4343', 'src')
         dest_path = os.path.join(self.app_resources_ios, 'src')
         Folder.copy(source_path, dest_path, clean_target=False)
-
+    
         # Replace main-view-model.js to call method from the source code in app resources
         source_js = os.path.join(Settings.TEST_RUN_HOME, 'assets', "issues", 'nativescript-cli-3650',
                                  'main-view-model.js')
         target_js = os.path.join(Settings.TEST_RUN_HOME, self.app_name, 'app', 'main-view-model.js')
         File.copy(source_js, target_js)
-
+    
         result = Tns.run_ios(self.app_name, emulator=True)
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.IOS,
                                        run_type=RunType.FIRST_TIME, device=self.sim)
         strings.append('Hey Native!')
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
-
+    
         # Verify app looks correct inside simulator
         self.sim.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
 
@@ -723,11 +723,11 @@ class TnsRunJSTests(TnsRunTest):
         """
         # Run the project with --justLaunch
         run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, just_launch=True)
-
+    
         # Delete node_modules
         node_modules = os.path.join(Settings.TEST_RUN_HOME, self.app_name, 'node_modules')
         Folder.clean(node_modules)
-
+    
         # Run the project again, verify it is build and node_modules folder exists
         run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, just_launch=True)
         assert Folder.exists(node_modules)
@@ -738,7 +738,8 @@ class TnsRunJSTests(TnsRunTest):
         `tns run ios` for apps with spaces
         """
         Tns.create(app_name=self.app_name_space, template=Template.HELLO_WORLD_JS.local_package, update=False)
-        run_hello_world_js_ts(self.app_name_space, Platform.ANDROID, self.emu, just_launch=True)
+        app_name = '"' + self.app_name_space + '"'
+        run_hello_world_js_ts(app_name, Platform.ANDROID, self.emu, just_launch=True)
 
     @unittest.skipIf(Settings.HOST_OS == OSType.LINUX, '`shell cp -r` fails for some reason on emulators on Linux.')
     def test_365_tns_run_android_should_respect_adb_errors(self):
@@ -748,7 +749,7 @@ class TnsRunJSTests(TnsRunTest):
         """
         # Deploy the app to make sure we have something at /data/data/org.nativescript.TestApp
         result = run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, just_launch=True)
-
+    
         # Use all the disk space on emulator
         for index in range(1, 3000):
             command = "shell cp -r /data/data/org.nativescript.TestApp /data/data/org.nativescript.TestApp" + str(index)
@@ -756,10 +757,10 @@ class TnsRunJSTests(TnsRunTest):
             Log.info(result.output)
             if "No space left on device" in result.output:
                 break
-
+    
         # Create new app
         Tns.create(app_name='TestApp2', template=Template.HELLO_WORLD_JS.local_package, update=False)
-
+    
         # Run the app and verify there is appropriate error
         result = Tns.run_android('TestApp2', verify=True, device=self.emu.id, just_launch=True)
         strings = ['No space left on device']

--- a/tests/cli/run/tests/run_tests.py
+++ b/tests/cli/run/tests/run_tests.py
@@ -98,7 +98,7 @@ class TnsRunJSTests(TnsTest):
                                        device=self.emu, run_type=RunType.UNKNOWN)
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
         self.emu.wait_for_text(text='Exception')
-    
+
         # Restore app.js and verify app is synced and recovered
         File.copy(app_js_backup_path, app_js_origin_path)
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID,
@@ -633,7 +633,7 @@ class TnsRunJSTests(TnsTest):
                      "<key>CFBundleIdentifier</key>" \
                      "<string>org.nativescript.myapp</string>"
         info_plist = os.path.join(Settings.TEST_RUN_HOME, self.app_resources_ios, 'Info.plist')
-    
+
         File.replace(info_plist, old_string, new_string)
 
         # Run the app on device and verify the warnings
@@ -699,7 +699,7 @@ class TnsRunJSTests(TnsTest):
 
         # Verify app looks correct inside simulator
         self.sim.wait_for_text(text=Changes.JSHelloWord.JS.old_text)
-    
+
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_350_tns_run_ios_source_code_in_app_resources(self):
         """

--- a/tests/cli/run/tests/run_tests.py
+++ b/tests/cli/run/tests/run_tests.py
@@ -97,6 +97,49 @@ class TnsRunJSTests(TnsRunTest):
         self.emu.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
         assert not self.emu.is_text_visible(text='Exception')
 
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_100_run_ios_break_and_fix_app(self):
+        """
+            Make changes in xml that break the app and then changes thet fix the app.
+            Add/remove js files thst break the app and then fix it. Verify recovery.
+        """
+        # Run app and verify on device
+        result = run_hello_world_js_ts(self.app_name, Platform.IOS, self.sim)
+
+        # Make changes in xml that will break the app
+        Sync.replace(self.app_name, Changes.JSHelloWord.XML_INVALID)
+        strings = ['main-page.xml', 'Error: Parsing XML']
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+        self.sim.wait_for_text(text='Exception')
+
+        # Revert changes
+        Sync.revert(self.app_name, Changes.JSHelloWord.XML_INVALID)
+
+        # Verify app is synced and recovered
+        strings = ['Successfully synced application']
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+        self.sim.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
+        assert not self.sim.is_text_visible(text='Exception')
+
+        # Delete app.js and verify app crash with error activity dialog
+        app_js_origin_path = os.path.join(self.source_project_dir, 'app', 'app.js')
+        app_js_backup_path = os.path.join(self.target_project_dir, 'app', 'app.js')
+        File.delete(app_js_origin_path)
+
+        # Verify app is synced
+        strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID,
+                                       device=self.sim, run_type=RunType.UNKNOWN)
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+        self.sim.wait_for_text(text='Exception')
+
+        # Restore app.js and verify app is synced and recovered
+        File.copy(app_js_backup_path, app_js_origin_path)
+        strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID,
+                                       run_type=RunType.UNKNOWN, device=self.emu)
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+        self.sim.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
+        assert not self.sim.is_text_visible(text='Exception')
+
     @unittest.skipIf(Settings.HOST_OS == OSType.WINDOWS, 'skip on windows untill we fix wait_rof_log method')
     def test_105_tns_run_android_changes_in_app_resounces(self):
         """


### PR DESCRIPTION
Plugin cocoa pod tests now run with web pack by default. 
We cannot assert for plugin files in platforms folder because they are not copied there any more. 
To assert if plugin is included we need to require it somewhere in the app and then check the bundle.js and vendor.js files.