### PR TITLE
fix: plugin cocoa pod tests

### DIFF
--- a/products/nativescript/tns_paths.py
+++ b/products/nativescript/tns_paths.py
@@ -43,7 +43,7 @@ class TnsPaths(object):
     def get_platforms_android_app_path(app_name, path=Settings.TEST_RUN_HOME):
         return os.path.join(TnsPaths.get_platforms_android_folder(app_name=app_name, path=path), 'app', 'src', 'main',
                             'assets', 'app')
-    
+
     @staticmethod
     def get_platforms_ios_app_path(app_name, path=Settings.TEST_RUN_HOME):
         return os.path.join(TnsPaths.get_platforms_ios_folder(app_name=app_name, path=path), app_name, 'app')

--- a/products/nativescript/tns_paths.py
+++ b/products/nativescript/tns_paths.py
@@ -43,6 +43,10 @@ class TnsPaths(object):
     def get_platforms_android_app_path(app_name, path=Settings.TEST_RUN_HOME):
         return os.path.join(TnsPaths.get_platforms_android_folder(app_name=app_name, path=path), 'app', 'src', 'main',
                             'assets', 'app')
+    
+    @staticmethod
+    def get_platforms_ios_app_path(app_name, path=Settings.TEST_RUN_HOME):
+        return os.path.join(TnsPaths.get_platforms_ios_folder(app_name=app_name, path=path), app_name, 'app')
 
     @staticmethod
     def get_platforms_android_npm_modules(app_name, path=Settings.TEST_RUN_HOME):
@@ -70,4 +74,10 @@ class TnsPaths(object):
 
     @staticmethod
     def get_bundle_id(app_name):
-        return 'org.nativescript.' + app_name.replace('-', '')
+        if '-' in app_name:
+            app_name = app_name.replace('-', '')
+        if ' ' in app_name:
+            app_name = app_name.replace(' ', '')
+        if '"' in app_name:
+            app_name = app_name.replace('"', '')
+        return 'org.nativescript.' + app_name

--- a/tests/cli/plugin/plugin_cocoapods_tests.py
+++ b/tests/cli/plugin/plugin_cocoapods_tests.py
@@ -126,11 +126,11 @@ class PluginCocoapodsTests(TnsTest):
 
             Tns.prepare_ios(self.app_name)
 
-            bundle_js =  File.read(os.path.join(TnsPaths.get_platforms_ios_app_path(self.app_name), 'bundle.js'))
-            vendor_js =  File.read(os.path.join(TnsPaths.get_platforms_ios_app_path(self.app_name), 'vendor.js'))
+            bundle_js = File.read(os.path.join(TnsPaths.get_platforms_ios_app_path(self.app_name), 'bundle.js'))
+            vendor_js = File.read(os.path.join(TnsPaths.get_platforms_ios_app_path(self.app_name), 'vendor.js'))
             assert '__webpack_require__("../node_modules/hello/hello-plugin.js")' in bundle_js
             assert 'hello = Hello.alloc().init();' in vendor_js
-            
+
             result = run(
                 "cat " + os.path.join(TnsPaths.get_platforms_ios_folder(self.app_name), 'TestApp.xcodeproj',
                                       'project.pbxproj | grep \"HelloLib.a\"'))

--- a/tests/cli/plugin/plugin_cocoapods_tests.py
+++ b/tests/cli/plugin/plugin_cocoapods_tests.py
@@ -44,7 +44,7 @@ class PluginCocoapodsTests(TnsTest):
                                             'package.json'))
             assert File.exists(os.path.join(TnsPaths.get_app_node_modules_path(self.app_name), 'carousel', 'platforms',
                                             'ios', 'Podfile'))
-            assert "carousel" in File.read(os.path.join(self.app_name, 'package.json'))
+            assert "carousel" in File.read(os.path.join(Settings.TEST_RUN_HOME, self.app_name, 'package.json'))
 
             plugin_path = os.path.join(Settings.TEST_RUN_HOME, 'assets', 'plugins', 'CocoaPods', 'keychain.tgz')
             result = Tns.plugin_add(plugin_path, path=Settings.AppName.DEFAULT)
@@ -53,12 +53,13 @@ class PluginCocoapodsTests(TnsTest):
                                             'package.json'))
             assert File.exists(os.path.join(TnsPaths.get_app_node_modules_path(self.app_name), 'keychain', 'platforms',
                                             'ios', 'Podfile'))
-            assert "keychain" in File.read(os.path.join(self.app_name, 'package.json'))
+            assert "keychain" in File.read(os.path.join(Settings.TEST_RUN_HOME, self.app_name, 'package.json'))
 
             result = Tns.prepare_ios(self.app_name)
             assert "Installing pods..." in result.output
-            assert "Successfully prepared plugin carousel for ios." in result.output
-            assert "Successfully prepared plugin keychain for ios." in result.output
+            # These asserts will be available again after we merge the webpack only branch for 6.0.0 release
+            # assert "Successfully prepared plugin carousel for ios." in result.output
+            # assert "Successfully prepared plugin keychain for ios." in result.output
 
             output = File.read(os.path.join(TnsPaths.get_platforms_ios_folder(self.app_name), 'Podfile'))
             assert "use_frameworks!" in output
@@ -119,12 +120,17 @@ class PluginCocoapodsTests(TnsTest):
             output = File.read(os.path.join(self.app_name, 'package.json'))
             assert "plugins/hello-plugin" in output
 
+            # Require the plugin so webpack can pick it up
+            main_js_file = os.path.join(Settings.TEST_RUN_HOME, self.app_name, 'app', 'main-page.js')
+            File.append(main_js_file, 'const hello = require("hello");')
+
             Tns.prepare_ios(self.app_name)
 
-            assert File.exists(os.path.join(TnsPaths.get_platforms_ios_folder(self.app_name), 'TestApp', 'app',
-                                            'tns_modules', 'hello', 'package.json'))
-            assert File.exists(os.path.join(TnsPaths.get_platforms_ios_folder(self.app_name), 'TestApp', 'app',
-                                            'tns_modules', 'hello', 'hello-plugin.js'))
+            bundle_js =  File.read(os.path.join(TnsPaths.get_platforms_ios_app_path(self.app_name), 'bundle.js'))
+            vendor_js =  File.read(os.path.join(TnsPaths.get_platforms_ios_app_path(self.app_name), 'vendor.js'))
+            assert '__webpack_require__("../node_modules/hello/hello-plugin.js")' in bundle_js
+            assert 'hello = Hello.alloc().init();' in vendor_js
+            
             result = run(
                 "cat " + os.path.join(TnsPaths.get_platforms_ios_folder(self.app_name), 'TestApp.xcodeproj',
                                       'project.pbxproj | grep \"HelloLib.a\"'))


### PR DESCRIPTION
Plugin cocoapod tests now run with web pack by default.
We cannot assert for plugin files in platforms folder because they are not copied there any more.
To assert if plugin is included we need to require it somewhere in the app and then check the bundle.js and vendor.js files.