### PR TITLE
feat: tests for app size

### DIFF
--- a/assets/template-min/package.json
+++ b/assets/template-min/package.json
@@ -3,18 +3,18 @@
         "id": "org.nativescript.HelloWorld",
         "templateVersion": "v2",
         "tns-android": {
-            "version": "5.1.0"
+            "version": "5.4.0"
         },
         "tns-ios": {
-            "version": "5.1.1"
+            "version": "5.4.0"
         }
     },
     "name": "tns-template-hello-world",
-    "version": "5.1.2",
+    "version": "5.4.0",
     "author": "Telerik <support@telerik.com>",
     "description": "Nativescript hello-world project template",
     "license": "Apache-2.0",
     "dependencies": {
-        "tns-core-modules": "~5.1.0"
+        "tns-core-modules": "~5.4.0"
     }
 }

--- a/core/base_test/tns_test.py
+++ b/core/base_test/tns_test.py
@@ -42,6 +42,7 @@ class TnsTest(unittest.TestCase):
         Folder.create(Settings.TEST_OUT_HOME)
         Folder.create(Settings.TEST_OUT_LOGS)
         Folder.create(Settings.TEST_OUT_IMAGES)
+        Folder.create(Settings.TEST_OUT_TEMP)
 
         # Set default simulator based on Xcode version
         if Settings.HOST_OS == OSType.OSX:
@@ -89,6 +90,7 @@ class TnsTest(unittest.TestCase):
         Tns.kill()
         TnsTest.kill_emulators()
         Process.kill_all_in_context()
+        Folder.clean(Settings.TEST_OUT_TEMP)
         Log.test_class_end(TestContext.CLASS_NAME)
 
     @staticmethod

--- a/core/settings/Settings.py
+++ b/core/settings/Settings.py
@@ -56,6 +56,7 @@ TEST_SUT_HOME = os.path.join(TEST_RUN_HOME, 'sut')
 TEST_OUT_HOME = os.path.join(TEST_RUN_HOME, 'out')
 TEST_OUT_LOGS = os.path.join(TEST_OUT_HOME, 'logs')
 TEST_OUT_IMAGES = os.path.join(TEST_OUT_HOME, 'images')
+TEST_OUT_TEMP = os.path.join(TEST_OUT_HOME, 'temp')
 
 ASSETS_HOME = os.path.join(TEST_RUN_HOME, 'assets')
 

--- a/core/utils/chrome/chrome.py
+++ b/core/utils/chrome/chrome.py
@@ -20,7 +20,7 @@ class Chrome(object):
             self.kill()
         path = ChromeDriverManager().install()
         Log.info('Starting Google Chrome ...')
-        profile_path = os.path.join(Settings.TEST_OUT_HOME, 'chrome_profile')
+        profile_path = os.path.join(Settings.TEST_OUT_TEMP, 'chrome_profile')
         Folder.clean(profile_path)
         options = webdriver.ChromeOptions()
         options.add_argument('user-data-dir={0}'.format(profile_path))

--- a/core/utils/chrome/chrome_dev_tools.py
+++ b/core/utils/chrome/chrome_dev_tools.py
@@ -73,7 +73,7 @@ class ChromeDevTools(object):
             Log.info('Expand dev tools main pannel.')
             button.click()
         else:
-            Log.info("Deb tools main panel already expanded.")
+            Log.info('Dev tools main panel already expanded.')
 
     def find_element_by_text(self, text, control='*', exact_match=False):
         self.__refresh_main_panel()

--- a/core/utils/device/adb.py
+++ b/core/utils/device/adb.py
@@ -141,7 +141,7 @@ class Adb(object):
 
     @staticmethod
     def get_page_source(device_id):
-        temp_file = os.path.join(Settings.TEST_OUT_HOME, 'window_dump.xml')
+        temp_file = os.path.join(Settings.TEST_OUT_TEMP, 'window_dump.xml')
         File.delete(temp_file)
         Adb.run_adb_command(command='shell rm /sdcard/window_dump.xml', device_id=device_id)
         result = Adb.run_adb_command(command='shell uiautomator dump', device_id=device_id)

--- a/core/utils/file_utils.py
+++ b/core/utils/file_utils.py
@@ -14,11 +14,11 @@ import stat
 import tarfile
 import zipfile
 
+from core.base_test.test_context import TestContext
 from core.enums.os_type import OSType
 from core.log.log import Log
 from core.settings import Settings
 from core.utils.process import Process
-from core.base_test.test_context import TestContext
 
 
 # noinspection PyBroadException
@@ -288,7 +288,10 @@ class File(object):
             Log.debug('Failed to unpack .tar file {0}'.format(file_path))
 
     @staticmethod
-    def unzip(file_path, dest_dir):
+    def unzip(file_path, dest_dir, clean_dest_dir=True):
+        if clean_dest_dir:
+            Folder.clean(dest_dir)
+            Folder.create(dest_dir)
         try:
             zfile = zipfile.ZipFile(file_path, 'r')
             zfile.extractall(dest_dir)
@@ -308,3 +311,7 @@ class File(object):
         file_path = os.path.join(destination_dir, file_name)
         assert File.exists(file_path), 'Failed to download {0} at {1}.'.format(url, file_path)
         Log.info('Downloaded {0} at {1}'.format(url, file_path))
+
+    @staticmethod
+    def get_size(file_path):
+        return os.path.getsize(file_path)

--- a/core_tests/e2e/core/test_adb.py
+++ b/core_tests/e2e/core/test_adb.py
@@ -17,6 +17,7 @@ class AdbTests(TnsRunAndroidTest):
         Folder.clean(Settings.TEST_OUT_HOME)
         Folder.create(Settings.TEST_OUT_LOGS)
         Folder.create(Settings.TEST_OUT_IMAGES)
+        Folder.create(Settings.TEST_OUT_TEMP)
         Process.kill(proc_name="adb")
         TnsRunAndroidTest.setUpClass()
         url = "https://github.com/webdriverio/native-demo-app/releases/download/0.2.1/Android-NativeDemoApp-0.2.1.apk"
@@ -40,7 +41,7 @@ class AdbTests(TnsRunAndroidTest):
         assert '</hierarchy>' in page_source
 
     def test_02_adb_get_screen(self):
-        path = os.path.join(Settings.TEST_OUT_HOME, 'temp.png')
+        path = os.path.join(Settings.TEST_OUT_TEMP, 'temp.png')
         File.delete(path)
         Adb.get_screen(device_id=self.emu.id, file_path=path)
 

--- a/products/nativescript/tns.py
+++ b/products/nativescript/tns.py
@@ -45,6 +45,8 @@ class Tns(object):
         :param snapshot: If true pass `--env.snapshot` to command.
         :param log_trace: If not None pass `--log <level>` to command.
         :param just_launch: If true pass `--justlaunch` to command.
+        :param sync_all_files:  If true pass `--syncAllFiles` to command.
+        :param clean:  If true pass `--clean` to command.
         :param options: Pass additional options as string.
         :param wait: If true it will wait until command is complete.
         :param timeout: Timeout for CLI command (respected only if wait=True).
@@ -207,11 +209,15 @@ class Tns(object):
     def plugin_add(plugin_name, path=None, log_trace=False, verify=True):
         result = Tns.exec_command(command="plugin add " + plugin_name, path=path, log_trace=log_trace)
         if verify:
+            # Verify output
             if "/src" in plugin_name:
                 short_name = plugin_name.rsplit('@', 1)[0].replace("/src", "").split(os.sep)[-1]
             else:
                 short_name = plugin_name.rsplit('@', 1)[0].replace(".tgz", "").split(os.sep)[-1]
             assert "Successfully installed plugin {0}".format(short_name) in result.output
+
+            # Verify package.json
+            App.is_dependency(app_name=path, dependency=short_name)
         return result
 
     @staticmethod
@@ -283,10 +289,24 @@ class Tns(object):
                                   provision=provision, for_device=for_device, bundle=bundle, aot=aot, uglify=uglify,
                                   snapshot=snapshot, wait=True, log_trace=log_trace)
         if verify:
+            # Verify output
             assert result.exit_code == 0, 'Build failed with non zero exit code.'
-            TnsAssert.build(app_name=app_name, platform=platform, release=False, provision=Settings.IOS.PROVISIONING,
-                            for_device=False, bundle=False, aot=False, uglify=False, snapshot=False, log_trace=False,
-                            output=result.output, app_data=app_data)
+            assert 'Project successfully built.' in result.output
+
+            # Verify apk, app or ipa produced
+            if platform == Platform.ANDROID:
+                assert File.exists(TnsPaths.get_apk_path(app_name=app_name, release=release))
+            if platform == Platform.IOS:
+                app_path = TnsPaths.get_ipa_path(app_name=app_name, release=release, for_device=for_device)
+                if for_device:
+                    assert File.exists(app_path)
+                else:
+                    assert Folder.exists(app_path)
+
+            # Verify based on app_data
+            if app_data is not None:
+                pass
+
         return result
 
     @staticmethod

--- a/products/nativescript/tns_assert.py
+++ b/products/nativescript/tns_assert.py
@@ -82,35 +82,8 @@ class TnsAssert(object):
         app_path = os.path.join(Settings.TEST_RUN_HOME, app_name)
         package_json = os.path.join(app_path, 'package.json')
         json = JsonUtils.read(package_json)
-        # noinspection SpellCheckingInspection
         assert json['nativescript']['tns-' + platform_string]['version'] is not None, \
             'tns-' + platform_string + ' not available in package.json of the app.'
-
-    # noinspection PyUnusedLocal
-    @staticmethod
-    def build(app_name, platform=None, release=False, provision=Settings.IOS.PROVISIONING, for_device=False,
-              bundle=False, aot=False, uglify=False, snapshot=False, log_trace=False, output=None, app_data=None):
-        # pylint: disable=unused-argument
-        # TODO: Implement it!
-
-        # Verify output and exit code
-        assert 'Project successfully built.' in output
-
-        # Assert app data
-        if app_data is not None:
-            # Assert app type
-            if app_data.app_type is AppType.JS:
-                pass
-            elif app_data.app_type is AppType.TS:
-                pass
-            elif app_data.app_type is AppType.NG:
-                pass
-            elif app_data.app_type is AppType.SHARED_NG:
-                pass
-
-            # Assert size
-            if app_data.size is not None:
-                pass
 
     @staticmethod
     def test_initialized(app_name, framework, output):

--- a/products/nativescript/tns_paths.py
+++ b/products/nativescript/tns_paths.py
@@ -6,13 +6,11 @@ from core.settings import Settings
 
 
 # noinspection PyUnusedLocal
-
-
 class TnsPaths(object):
 
     @staticmethod
     def get_app_path(app_name, path=Settings.TEST_RUN_HOME):
-        return os.path.join(path, app_name)
+        return os.path.join(path, app_name.replace('"', ''))
 
     @staticmethod
     def get_app_node_modules_path(app_name, path=Settings.TEST_RUN_HOME):
@@ -59,14 +57,27 @@ class TnsPaths(object):
                             'app', 'tns_modules')
 
     @staticmethod
-    def get_apk_path(app_name, path=Settings.TEST_RUN_HOME):
-        return os.path.join(TnsPaths.get_platforms_android_folder(app_name=app_name, path=path), 'app', 'build',
-                            'outputs', 'apk')
+    def get_apk_path(app_name, release=False, path=Settings.TEST_RUN_HOME):
+        build_path = os.path.join(TnsPaths.get_platforms_android_folder(app_name=app_name, path=path), 'app', 'build')
+        if release:
+            return os.path.join(build_path, 'outputs', 'apk', 'release', 'app-release.apk')
+        else:
+            return os.path.join(build_path, 'outputs', 'apk', 'debug', 'app-debug.apk')
 
     @staticmethod
-    def get_ipa_path(app_name, path=Settings.TEST_RUN_HOME):
-        return os.path.join(TnsPaths.get_platforms_ios_folder(app_name=app_name, path=path), 'build',
-                            'Debug-iphonesimulator')
+    def get_ipa_path(app_name, for_device=False, release=False, path=Settings.TEST_RUN_HOME):
+        app_name = TnsPaths.__get_trimmed_app_name(app_name=app_name)
+        base_path = os.path.join(TnsPaths.get_platforms_ios_folder(app_name=app_name, path=path), 'build')
+        if for_device:
+            if release:
+                return os.path.join(base_path, 'Release-iphoneos', '{0}.ipa'.format(app_name))
+            else:
+                return os.path.join(base_path, 'Debug-iphoneos', '{0}.ipa'.format(app_name))
+        else:
+            if release:
+                return os.path.join(base_path, 'Release-iphonesimulator', '{0}.app'.format(app_name))
+            else:
+                return os.path.join(base_path, 'Debug-iphonesimulator', '{0}.app'.format(app_name))
 
     @staticmethod
     def get_app_ios_path(app_name, path=Settings.TEST_RUN_HOME):
@@ -74,10 +85,19 @@ class TnsPaths(object):
 
     @staticmethod
     def get_bundle_id(app_name):
+        return 'org.nativescript.' + TnsPaths.__get_trimmed_app_name(app_name=app_name)
+
+    @staticmethod
+    def __get_trimmed_app_name(app_name):
+        """
+        Get app name in format for bundle id or native platforms.
+        :param app_name: App name.
+        :return: Formated app name.
+        """
         if '-' in app_name:
             app_name = app_name.replace('-', '')
         if ' ' in app_name:
             app_name = app_name.replace(' ', '')
         if '"' in app_name:
             app_name = app_name.replace('"', '')
-        return 'org.nativescript.' + app_name
+        return app_name

--- a/run_common.py
+++ b/run_common.py
@@ -22,6 +22,7 @@ def __cleanup():
     Folder.clean(Settings.TEST_OUT_HOME)
     Folder.create(Settings.TEST_OUT_LOGS)
     Folder.create(Settings.TEST_OUT_IMAGES)
+    Folder.create(Settings.TEST_OUT_TEMP)
 
     DeviceManager.Emulator.stop()
     if Settings.HOST_OS == OSType.OSX:

--- a/tests/cli/build/build_tests.py
+++ b/tests/cli/build/build_tests.py
@@ -194,8 +194,7 @@ class BuildTests(TnsTest):
         assert not File.exists(os.path.join(TnsPaths.get_platforms_ios_npm_modules(self.app_name), '*.framework'))
 
         # Verify ipa has both armv7 and arm64 archs
-        ipa_path = os.path.join(TnsPaths.get_platforms_ios_folder(self.app_name), 'build', 'Release-iphoneos',
-                                'TestApp.ipa')
+        ipa_path = TnsPaths.get_ipa_path(app_name=self.app_name, release=True, for_device=True)
         run("mv " + ipa_path + " TestApp-ipa.tgz")
         run("unzip -o TestApp-ipa.tgz")
         result = run("lipo -info Payload/TestApp.app/TestApp")

--- a/tests/cli/build/build_tests.py
+++ b/tests/cli/build/build_tests.py
@@ -71,10 +71,11 @@ class BuildTests(TnsTest):
         # Verify apk does not contain aar files
         apk_path = TnsPaths.get_apk_path(app_name=self.app_name, release=False)
         File.unzip(apk_path, 'temp')
+
         # Clean META-INF folder. It contains com.android.support.... files which are expected to be there due to
         # https://github.com/NativeScript/nativescript-cli/pull/3923
-        Folder.clean(os.path.join(self.app_path, 'temp', 'META-INF'))
         temp_folder = os.path.join(self.app_path, 'temp')
+        Folder.clean(os.path.join(temp_folder, 'META-INF'))
         assert not File.pattern_exists(temp_folder, '*.aar')
         assert not File.pattern_exists(temp_folder, '*.plist')
         assert not File.pattern_exists(temp_folder, '*.android.*')

--- a/tests/cli/build/build_tests.py
+++ b/tests/cli/build/build_tests.py
@@ -20,7 +20,6 @@ class BuildTests(TnsTest):
     app_path = TnsPaths.get_app_path(app_name=app_name)
     app_temp_path = os.path.join(Settings.TEST_RUN_HOME, 'data', 'temp', 'TestApp')
     debug_apk = "app-debug.apk"
-    release_apk = "app-release.apk"
     app_identifier = "org.nativescript.testapp"
 
     @classmethod
@@ -46,8 +45,8 @@ class BuildTests(TnsTest):
     @classmethod
     def tearDownClass(cls):
         TnsTest.tearDownClass()
-        Folder.clean(cls.app_temp_path)
-        Folder.clean(cls.app_name_with_space)
+        Folder.clean(TnsPaths.get_app_path(app_name=cls.app_temp_path))
+        Folder.clean(TnsPaths.get_app_path(cls.app_name_with_space))
 
     def test_001_build_android(self):
         Tns.build_android(self.app_name, bundle=True)
@@ -55,13 +54,13 @@ class BuildTests(TnsTest):
         assert not File.exists(os.path.join(TnsPaths.get_platforms_android_folder(self.app_name), '*.android.js'))
         assert not File.exists(os.path.join(TnsPaths.get_platforms_android_folder(self.app_name), '*.ios.js'))
 
-        src = os.path.join(self.app_name, 'app', 'app.js')
-        dest_1 = os.path.join(self.app_name, 'app', 'new.android.js')
-        dest_2 = os.path.join(self.app_name, 'app', 'new.ios.js')
+        src = os.path.join(self.app_path, 'app', 'app.js')
+        dest_1 = os.path.join(self.app_path, 'app', 'new.android.js')
+        dest_2 = os.path.join(self.app_path, 'app', 'new.ios.js')
         File.copy(src, dest_1)
         File.copy(src, dest_2)
 
-        result = Tns.build_android(self.app_name, bundle=True)
+        result = Tns.build_android(self.app_path, bundle=True)
         assert "Gradle build..." in result.output, "Gradle build not called."
         assert result.output.count("Gradle build...") == 1, "Only one gradle build is triggered."
 
@@ -70,12 +69,12 @@ class BuildTests(TnsTest):
         assert not File.exists(os.path.join(TnsPaths.get_platforms_android_folder(self.app_name), '*.ios.js'))
 
         # Verify apk does not contain aar files
-        archive = os.path.join(TnsPaths.get_apk_path(self.app_name), self.debug_apk)
-        File.unzip(archive, 'temp')
+        apk_path = TnsPaths.get_apk_path(app_name=self.app_name, release=False)
+        File.unzip(apk_path, 'temp')
         # Clean META-INF folder. It contains com.android.support.... files which are expected to be there due to
         # https://github.com/NativeScript/nativescript-cli/pull/3923
-        Folder.clean(os.path.join(self.app_name, 'temp', 'META-INF'))
-        temp_folder = os.path.join(self.app_name, 'temp')
+        Folder.clean(os.path.join(self.app_path, 'temp', 'META-INF'))
+        temp_folder = os.path.join(self.app_path, 'temp')
         assert not File.pattern_exists(temp_folder, '*.aar')
         assert not File.pattern_exists(temp_folder, '*.plist')
         assert not File.pattern_exists(temp_folder, '*.android.*')
@@ -92,16 +91,12 @@ class BuildTests(TnsTest):
     def test_002_build_android_release(self):
         Tns.build_android(self.app_name, bundle=True, release=True)
 
-        # Configs are respected
-        assert File.exists(os.path.join(TnsPaths.get_apk_path(self.app_name), 'release', self.release_apk))
-
         # Create zip
         command = "tar -czf " + self.app_name + "/app/app.tar.gz " + self.app_name + "/app/app.js"
-        run(command, wait=True)
-        assert File.exists(os.path.join(self.app_name, 'app', 'app.tar.gz'))
+        run(cmd=command, cwd=Settings.TEST_RUN_HOME, wait=True)
+        assert File.exists(os.path.join(self.app_path, 'app', 'app.tar.gz'))
 
     def test_301_build_project_with_space_release(self):
-
         # Ensure ANDROID_KEYSTORE_PATH contain spaces (verification for CLI issue 2650)
         Folder.create("with space")
         file_name = os.path.basename(Settings.Android.ANDROID_KEYSTORE_PATH)
@@ -117,10 +112,10 @@ class BuildTests(TnsTest):
         assert self.app_identifier in output.lower()
 
     def test_302_build_project_with_space_debug_with_plugin(self):
+        app_space_path = TnsPaths.get_app_path(app_name=self.app_name_with_space)
         Tns.platform_remove(app_name='"' + self.app_name_with_space + '"', platform=Platform.ANDROID)
-        Npm.install(package='nativescript-mapbox', option='--save', folder=self.app_name_with_space)
-        result = Tns.build_android(app_name='"' + self.app_name_with_space + '"', bundle=True)
-        assert "Project successfully built" in result.output
+        Npm.install(package='nativescript-mapbox', option='--save', folder=app_space_path)
+        Tns.build_android(app_name='"' + self.app_name_with_space + '"', bundle=True)
 
     def test_310_build_android_with_custom_compile_sdk_new(self):
         Tns.platform_remove(self.app_name, platform=Platform.ANDROID)

--- a/tests/cli/plugin/plugin_tests.py
+++ b/tests/cli/plugin/plugin_tests.py
@@ -42,9 +42,6 @@ class PluginTests(TnsTest):
 
     def test_100_plugin_add(self):
         Tns.plugin_add(plugin_name='tns-plugin', path=self.app_name)
-        assert File.exists(os.path.join(TnsPaths.get_app_node_modules_path(self.app_name), 'tns-plugin', 'index.js'))
-        assert File.exists(os.path.join(TnsPaths.get_app_node_modules_path(self.app_name), 'tns-plugin',
-                                        'package.json'))
 
         # Verify files of the plugin
         plugin_path = os.path.join(TnsPaths.get_app_node_modules_path(self.app_name), 'tns-plugin')

--- a/tests/cli/plugin/plugin_tests.py
+++ b/tests/cli/plugin/plugin_tests.py
@@ -40,30 +40,59 @@ class PluginTests(TnsTest):
         TnsTest.tearDownClass()
         Folder.clean(cls.app_temp_path)
 
-    def test_100_plugin_add_after_platform_add_android(self):
-        result = Tns.plugin_add(plugin_name='tns-plugin', path=self.app_name)
-        assert 'Successfully installed plugin tns-plugin' in result.output
+    def test_100_plugin_add(self):
+        Tns.plugin_add(plugin_name='tns-plugin', path=self.app_name)
         assert File.exists(os.path.join(TnsPaths.get_app_node_modules_path(self.app_name), 'tns-plugin', 'index.js'))
         assert File.exists(os.path.join(TnsPaths.get_app_node_modules_path(self.app_name), 'tns-plugin',
                                         'package.json'))
 
-        output = File.read(os.path.join(self.app_path, 'package.json'))
-        assert 'org.nativescript.TestApp' in output
-        assert 'dependencies' in output
-        assert 'tns-plugin' in output
+        # Verify files of the plugin
+        plugin_path = os.path.join(TnsPaths.get_app_node_modules_path(self.app_name), 'tns-plugin')
+        assert File.exists(os.path.join(plugin_path, 'index.js'))
+        assert File.exists(os.path.join(plugin_path, 'package.json'))
+        assert File.exists(os.path.join(plugin_path, 'test.android.js'))
+        assert File.exists(os.path.join(plugin_path, 'test.ios.js'))
+        assert File.exists(os.path.join(plugin_path, 'test2.android.xml'))
+        assert File.exists(os.path.join(plugin_path, 'test2.ios.xml'))
 
-    def test_101_plugin_add_prepare_verify_apk_android(self):
-        Tns.plugin_add(plugin_name='tns-plugin', path=self.app_name)
-        Tns.build_android(app_name=self.app_name)
-        assert File.exists(os.path.join(TnsPaths.get_apk_path(self.app_name), 'debug', 'app-debug.apk'))
-        assert File.exists(os.path.join(TnsPaths.get_platforms_android_npm_modules(self.app_name), 'tns-plugin',
-                                        'index.js'))
-
-    def test_102_plugin_add_verify_command_list_used_plugins_android(self):
-        Tns.plugin_add(plugin_name='tns-plugin', path=self.app_name)
-        Tns.prepare_android(app_name=self.app_name)
+        # Verify plugin list show installed plugins
         result = Tns.exec_command(command='plugin', path=self.app_name)
         assert 'tns-plugin' in result.output
+
+    def test_101_plugin_add_and_build(self):
+        Tns.plugin_add(plugin_name='tns-plugin', path=self.app_name)
+
+        # Build Android
+        Tns.build_android(app_name=self.app_name, bundle=False)
+
+        # Verify permissions are merged
+        apk_path = TnsPaths.get_apk_path(app_name=self.app_name, release=False)
+        output = Adb.get_package_permission(apk_path)
+        assert 'android.permission.READ_EXTERNAL_STORAGE' in output
+        assert 'android.permission.WRITE_EXTERNAL_STORAGE' in output
+        assert 'android.permission.INTERNET' in output
+
+        # Verify Platforms files
+        plugin_android_path = os.path.join(TnsPaths.get_platforms_android_npm_modules(self.app_name), 'tns-plugin')
+        assert File.exists(os.path.join(plugin_android_path, 'index.js'))
+        assert File.exists(os.path.join(plugin_android_path, 'test.js'))
+        assert File.exists(os.path.join(plugin_android_path, 'test2.xml'))
+        assert not File.exists(os.path.join(plugin_android_path, 'test.ios.js'))
+        assert not File.exists(os.path.join(plugin_android_path, 'test2.ios.xml'))
+        assert not File.exists(os.path.join(plugin_android_path, 'test.android.js'))
+        assert not File.exists(os.path.join(plugin_android_path, 'test2.android.xml'))
+
+        # Build IOS
+        if Settings.HOST_OS is OSType.OSX:
+            Tns.build_ios(app_name=self.app_name, bundle=False)
+            plugin_ios_path = os.path.join(TnsPaths.get_platforms_ios_npm_modules(self.app_name), 'tns-plugin')
+            assert File.exists(os.path.join(plugin_ios_path, 'index.js'))
+            assert File.exists(os.path.join(plugin_ios_path, 'test.js'))
+            assert File.exists(os.path.join(plugin_ios_path, 'test2.xml'))
+            assert not File.exists(os.path.join(plugin_ios_path, 'test.ios.js'))
+            assert not File.exists(os.path.join(plugin_ios_path, 'test2.ios.xml'))
+            assert not File.exists(os.path.join(plugin_ios_path, 'test.android.js'))
+            assert not File.exists(os.path.join(plugin_ios_path, 'test2.android.xml'))
 
     def test_200_plugin_platforms_should_not_exist_in_tns_modules_android(self):
         """
@@ -83,7 +112,7 @@ class PluginTests(TnsTest):
         Tns.platform_add_android(app_name=self.app_name, framework_path=Settings.Android.FRAMEWORK_PATH)
         folder_path = os.path.join(self.app_path, 'nativescript-ui-listview')
         Npm.install(option='--ignore-scripts', folder=folder_path)
-        Tns.build_android(app_name=self.app_name)
+        Tns.build_android(app_name=self.app_name, bundle=False)
         app_path = os.path.join(TnsPaths.get_platforms_android_npm_modules(self.app_name))
         assert not File.exists(os.path.join(app_path, 'nativescript-ui-listview', 'node_modules',
                                             'nativescript-ui-core', 'platforms'))
@@ -102,7 +131,8 @@ class PluginTests(TnsTest):
         assert 'ERR!' not in output
         assert 'nativescript-appversion@' in output
 
-        Tns.build_android(app_name=self.app_name, verify=False)
+        Tns.build_android(app_name=self.app_name, bundle=False)
+
         # Verify plugin and npm module files
         assert File.exists(os.path.join(TnsPaths.get_platforms_android_npm_modules(self.app_name),
                                         'nativescript-social-share', 'package.json'))
@@ -127,76 +157,16 @@ class PluginTests(TnsTest):
         """
         Tns.platform_remove(app_name=self.app_name, platform=Platform.ANDROID)
         Tns.plugin_add(plugin_name='nativescript-socket.io', path=self.app_name)
-        assert Folder.exists(os.path.join(self.app_name, 'node_modules', 'nativescript-socket.io'))
+        assert Folder.exists(os.path.join(self.app_path, 'node_modules', 'nativescript-socket.io'))
         result = Tns.plugin_remove(plugin_name='nativescript-socket.io', path=self.app_name, log_trace=True)
         assert 'Successfully removed plugin nativescript-socket.io' in result.output
         assert 'stdout: removed 1 package' in result.output
         assert 'Exec npm uninstall nativescript-socket.io --save' in result.output
-        output = File.read(os.path.join(self.app_name, 'package.json'))
+        output = File.read(os.path.join(self.app_path, 'package.json'))
         assert 'nativescript-socket.io' not in output
 
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
-    def test_101_plugin_add_prepare_verify_app_ios(self):
-        Tns.plugin_add(plugin_name='tns-plugin', path=self.app_name)
-        Tns.build_ios(app_name=self.app_name)
-        path_app = os.path.join(TnsPaths.get_ipa_path(self.app_name), 'TestApp.app')
-        assert Folder.exists(path_app)
-        assert File.exists(os.path.join(TnsPaths.get_platforms_ios_npm_modules(self.app_name),
-                                        'tns-plugin', 'index.js'))
-
-    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
-    def test_201_build_app_for_both_platforms(self):
-        Tns.plugin_add(plugin_name='tns-plugin', path=self.app_name)
-
-        # Verify files of the plugin
-        assert File.exists(os.path.join(TnsPaths.get_app_node_modules_path(self.app_name), 'tns-plugin', 'index.js'))
-        assert File.exists(os.path.join(TnsPaths.get_app_node_modules_path(self.app_name), 'tns-plugin',
-                                        'package.json'))
-        assert File.exists(os.path.join(TnsPaths.get_app_node_modules_path(self.app_name), 'tns-plugin',
-                                        'test.android.js'))
-        assert File.exists(os.path.join(TnsPaths.get_app_node_modules_path(self.app_name), 'tns-plugin', 'test.ios.js'))
-        assert File.exists(os.path.join(TnsPaths.get_app_node_modules_path(self.app_name), 'tns-plugin',
-                                        'test2.android.xml'))
-        assert File.exists(os.path.join(TnsPaths.get_app_node_modules_path(self.app_name), 'tns-plugin',
-                                        'test2.ios.xml'))
-
-        Tns.build_ios(app_name=self.app_name)
-        Tns.build_android(app_name=self.app_name)
-
-        # # Verify platform specific files
-        assert File.exists(os.path.join(TnsPaths.get_platforms_ios_npm_modules(self.app_name), 'tns-plugin', 'test.js'))
-        assert File.exists(os.path.join(TnsPaths.get_platforms_ios_npm_modules(self.app_name),
-                                        'tns-plugin', 'test2.xml'))
-        assert not File.exists(os.path.join(TnsPaths.get_platforms_ios_npm_modules(self.app_name),
-                                            'tns-plugin', 'test.ios.js'))
-        assert not File.exists(os.path.join(TnsPaths.get_platforms_ios_npm_modules(self.app_name),
-                                            'tns-plugin', 'test2.ios.xml'))
-        assert not File.exists(os.path.join(TnsPaths.get_platforms_ios_npm_modules(self.app_name),
-                                            'tns-plugin', 'test.android.js'))
-        assert not File.exists(os.path.join(TnsPaths.get_platforms_ios_npm_modules(self.app_name),
-                                            'tns-plugin', 'test2.android.xml'))
-
-        assert File.exists(
-            os.path.join(TnsPaths.get_platforms_android_npm_modules(self.app_name), 'tns-plugin', 'test.js'))
-        assert File.exists(
-            os.path.join(TnsPaths.get_platforms_android_npm_modules(self.app_name), 'tns-plugin', 'test2.xml'))
-        assert not File.exists(
-            os.path.join(TnsPaths.get_platforms_android_npm_modules(self.app_name), 'tns-plugin', 'test.ios.js'))
-        assert not File.exists(
-            os.path.join(TnsPaths.get_platforms_android_npm_modules(self.app_name), 'tns-plugin', 'test2.ios.xml'))
-        assert not File.exists(
-            os.path.join(TnsPaths.get_platforms_android_npm_modules(self.app_name), 'tns-plugin', 'test.android.js'))
-        assert not File.exists(
-            os.path.join(TnsPaths.get_platforms_android_npm_modules(self.app_name), 'tns-plugin', 'test2.android.xml'))
-
-        apk_path = os.path.join(TnsPaths.get_apk_path(self.app_name), 'debug', 'app-debug.apk')
-        output = Adb.get_package_permission(apk_path)
-        assert 'android.permission.READ_EXTERNAL_STORAGE' in output
-        assert 'android.permission.WRITE_EXTERNAL_STORAGE' in output
-        assert 'android.permission.INTERNET' in output
-
-    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
-    def test_311_plugin_platforms_should_not_exist_in_tnsmodules_ios(self):
+    def test_311_plugin_platforms_should_not_exist_in_tns_modules_ios(self):
         """
         Test for issue https://github.com/NativeScript/nativescript-cli/issues/3932
         """
@@ -213,7 +183,7 @@ class PluginTests(TnsTest):
         Tns.platform_add_ios(app_name=self.app_name, framework_path=Settings.IOS.FRAMEWORK_PATH)
         folder_path = os.path.join(self.app_name, 'nativescript-ui-listview')
         Npm.install(option='--ignore-scripts', folder=folder_path)
-        Tns.build_ios(app_name=self.app_name)
+        Tns.build_ios(app_name=self.app_name, bundle=False)
         app_path = os.path.join(TnsPaths.get_platforms_ios_folder(self.app_name))
         assert not File.exists(
             os.path.join(app_path, 'nativescript-ui-listview', 'node_modules', 'nativescript-ui-core', 'platforms'))
@@ -254,12 +224,12 @@ class PluginTests(TnsTest):
         assert 'acra-telerik-analytics is not supported for ios' in result.output
         assert 'Successfully installed plugin acra-telerik-analytics' in result.output
 
-        Tns.build_ios(app_name=self.app_name)
+        Tns.build_ios(app_name=self.app_name, bundle=False)
         ios_path = os.path.join(TnsPaths.get_platforms_ios_folder(self.app_name))
         assert not File.pattern_exists(ios_path, pattern='*.aar')
         assert not File.pattern_exists(ios_path, pattern='*acra*')
 
-        Tns.build_android(app_name=self.app_name)
+        Tns.build_android(app_name=self.app_name, bundle=False)
         android_path = os.path.join(TnsPaths.get_platforms_android_folder(self.app_name))
         assert File.pattern_exists(android_path, pattern='*.aar')
         assert File.pattern_exists(android_path, pattern='*acra*')

--- a/tests/perf/app_size/test_app_size.py
+++ b/tests/perf/app_size/test_app_size.py
@@ -1,0 +1,45 @@
+"""
+Tests for app size ot {N} apps.
+"""
+import unittest
+
+from core.base_test.tns_test import TnsTest
+from core.enums.os_type import OSType
+from core.settings import Settings
+from data.templates import Template
+from products.nativescript.tns import Tns
+
+
+class AppSizeTests(TnsTest):
+    js_app = Settings.AppName.DEFAULT + 'JS'
+    ng_app = Settings.AppName.DEFAULT + 'NG'
+
+    @classmethod
+    def setUpClass(cls):
+        TnsTest.setUpClass()
+
+        # Create JS app and copy to temp data folder
+        Tns.create(app_name=cls.js_app, template=Template.HELLO_WORLD_JS.local_package, update=False)
+        Tns.platform_add_android(app_name=cls.js_app, framework_path=Settings.Android.FRAMEWORK_PATH)
+        if Settings.HOST_OS is OSType.OSX:
+            Tns.platform_add_ios(app_name=cls.js_app, framework_path=Settings.IOS.FRAMEWORK_PATH)
+
+        # Create NG app and copy to temp data folder
+        Tns.create(app_name=cls.ng_app, template=Template.HELLO_WORLD_NG.local_package, update=False)
+        Tns.platform_add_android(app_name=cls.ng_app, framework_path=Settings.Android.FRAMEWORK_PATH)
+        if Settings.HOST_OS is OSType.OSX:
+            Tns.platform_add_ios(app_name=cls.ng_app, framework_path=Settings.IOS.FRAMEWORK_PATH)
+
+    def test_001_android_app_size_js(self):
+        Tns.build_android(self.js_app, release=True, bundle=True, aot=True, uglify=True, snapshot=True)
+
+    def test_002_android_app_size_ng(self):
+        Tns.build_android(self.ng_app, release=True, bundle=True, aot=True, uglify=True, snapshot=True)
+
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_001_ios_app_size_js(self):
+        Tns.build_ios(self.js_app, release=True, bundle=True, aot=True, uglify=True, for_device=True)
+
+    @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_002_ios_appandroi_size_ng(self):
+        Tns.build_ios(self.ng_app, release=True, bundle=True, aot=True, uglify=True, for_device=True)

--- a/tests/perf/app_size/test_app_size.py
+++ b/tests/perf/app_size/test_app_size.py
@@ -43,10 +43,6 @@ class AppSizeTests(TnsTest):
             Tns.build_ios(cls.js_app, release=True, bundle=True, aot=True, uglify=True, for_device=True)
             Tns.build_ios(cls.ng_app, release=True, bundle=True, aot=True, uglify=True, for_device=True)
 
-    @classmethod
-    def tearDownClass(cls):
-        TnsTest.tearDownClass()
-
     def test_001_js_app_app_resources(self):
         folder = os.path.join(TnsPaths.get_app_path(app_name=self.js_app), 'app')
         assert PerfUtils.is_value_in_range(actual=Folder.get_size(folder), expected=2991521, tolerance=0.1)

--- a/tests/perf/app_size/test_app_size.py
+++ b/tests/perf/app_size/test_app_size.py
@@ -66,24 +66,24 @@ class AppSizeTests(TnsTest):
         # Verify content of APK
         assert PerfUtils.is_value_in_range(actual=Folder.get_size(lib), expected=36968864, tolerance=0.05)
         assert PerfUtils.is_value_in_range(actual=Folder.get_size(res), expected=796563, tolerance=0.05)
-        assert PerfUtils.is_value_in_range(actual=Folder.get_size(assets_app), expected=639791, tolerance=0.05)
-        assert PerfUtils.is_value_in_range(actual=Folder.get_size(assets_snapshots), expected=5795968, tolerance=0.05)
+        assert PerfUtils.is_value_in_range(actual=Folder.get_size(assets_app), expected=641606, tolerance=0.05)
+        assert PerfUtils.is_value_in_range(actual=Folder.get_size(assets_snapshots), expected=5811260, tolerance=0.05)
 
         # Verify final apk size
-        assert PerfUtils.is_value_in_range(actual=File.get_size(apk), expected=18213523, tolerance=0.05)
+        assert PerfUtils.is_value_in_range(actual=File.get_size(apk), expected=18216351, tolerance=0.05)
 
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_102_js_app_ipa(self):
         ipa = TnsPaths.get_ipa_path(app_name=self.js_app, release=True, for_device=True)
-        assert PerfUtils.is_value_in_range(actual=File.get_size(ipa), expected=16000288, tolerance=0.05)
+        assert PerfUtils.is_value_in_range(actual=File.get_size(ipa), expected=16001936, tolerance=0.05)
 
     def test_100_ng_app_app_resources(self):
         app_folder = os.path.join(TnsPaths.get_app_path(app_name=self.ng_app), 'App_Resources')
-        assert PerfUtils.is_value_in_range(actual=Folder.get_size(app_folder), expected=2991521, tolerance=0.1)
+        assert PerfUtils.is_value_in_range(actual=Folder.get_size(app_folder), expected=2986244, tolerance=0.1)
 
     def test_101_ng_app_node_modules(self):
         app_folder = os.path.join(TnsPaths.get_app_path(app_name=self.ng_app), 'node_modules')
-        assert PerfUtils.is_value_in_range(actual=Folder.get_size(app_folder), expected=200232878, tolerance=0.2)
+        assert PerfUtils.is_value_in_range(actual=Folder.get_size(app_folder), expected=200248003, tolerance=0.2)
 
     def test_102_ng_app_apk(self):
         # Extract APK
@@ -100,13 +100,13 @@ class AppSizeTests(TnsTest):
 
         assert PerfUtils.is_value_in_range(actual=Folder.get_size(lib), expected=36968864, tolerance=0.05)
         assert PerfUtils.is_value_in_range(actual=Folder.get_size(res), expected=796563, tolerance=0.05)
-        assert PerfUtils.is_value_in_range(actual=Folder.get_size(assets_app), expected=1340636, tolerance=0.05)
-        assert PerfUtils.is_value_in_range(actual=Folder.get_size(assets_snapshots), expected=13140964, tolerance=0.05)
+        assert PerfUtils.is_value_in_range(actual=Folder.get_size(assets_app), expected=1342382, tolerance=0.05)
+        assert PerfUtils.is_value_in_range(actual=Folder.get_size(assets_snapshots), expected=13157964, tolerance=0.05)
 
         # Verify final apk size
-        assert PerfUtils.is_value_in_range(actual=File.get_size(apk), expected=20083898, tolerance=0.05)
+        assert PerfUtils.is_value_in_range(actual=File.get_size(apk), expected=20087522, tolerance=0.05)
 
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_102_ng_app_ipa(self):
         ipa = TnsPaths.get_ipa_path(app_name=self.ng_app, release=True, for_device=True)
-        assert PerfUtils.is_value_in_range(actual=File.get_size(ipa), expected=16183587, tolerance=0.05)
+        assert PerfUtils.is_value_in_range(actual=File.get_size(ipa), expected=16185128, tolerance=0.05)

--- a/tests/perf/app_size/test_app_size.py
+++ b/tests/perf/app_size/test_app_size.py
@@ -25,13 +25,13 @@ class AppSizeTests(TnsTest):
         TnsTest.setUpClass()
 
         # Create JS app and copy to temp data folder
-        Tns.create(app_name=cls.js_app, template=Template.HELLO_WORLD_JS.local_package, update=False)
+        Tns.create(app_name=cls.js_app, template=Template.HELLO_WORLD_JS.local_package, update=True)
         Tns.platform_add_android(app_name=cls.js_app, framework_path=Settings.Android.FRAMEWORK_PATH)
         if Settings.HOST_OS is OSType.OSX:
             Tns.platform_add_ios(app_name=cls.js_app, framework_path=Settings.IOS.FRAMEWORK_PATH)
 
         # Create NG app and copy to temp data folder
-        Tns.create(app_name=cls.ng_app, template=Template.HELLO_WORLD_NG.local_package, update=False)
+        Tns.create(app_name=cls.ng_app, template=Template.HELLO_WORLD_NG.local_package, update=True)
         Tns.platform_add_android(app_name=cls.ng_app, framework_path=Settings.Android.FRAMEWORK_PATH)
         if Settings.HOST_OS is OSType.OSX:
             Tns.platform_add_ios(app_name=cls.ng_app, framework_path=Settings.IOS.FRAMEWORK_PATH)

--- a/tests/perf/runtime/todo.md
+++ b/tests/perf/runtime/todo.md
@@ -1,1 +1,0 @@
-# Tests for Startup Time of {N} apps


### PR DESCRIPTION
**New:**
- Tests for app size of {N} Apps.
- Asserts in Tns.build() that binary exists after build
- Introduce Settings.TEST_OUT_TEMP folder for temp things
- Starting Chrome now happens with user profile in Settings.TEST_OUT_TEMP
- We clean Settings.TEST_OUT_TEMP after in TnsTest.tearDownClass() so we do not attach big artifacts in Jenkins

**Refactoring**
- Get path to apk, app or ipa
- Apply changes caused by item above in all related tests

**Other**
- Update version in min template to 5.4
- Fix typo in chrome_dev_tools.py