### PR TITLE
fix: fixes cli tests

### DIFF
--- a/data/sync/hello_world_js.py
+++ b/data/sync/hello_world_js.py
@@ -194,7 +194,7 @@ def preview_sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_string_list)
     else:
-        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=90)
     device.wait_for_text(text=js_change.new_text)
 
     # Edit XML file and verify changes are applied
@@ -205,7 +205,7 @@ def preview_sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_string_list)
     else:
-        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=90)
     device.wait_for_text(text=xml_change.new_text)
     device.wait_for_text(text=js_change.new_text)
 
@@ -217,7 +217,7 @@ def preview_sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_string_list)
     else:
-        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=90)
     device.wait_for_color(color=Colors.LIGHT_BLUE, pixel_count=blue_count * 2, delta=25)
     device.wait_for_text(text=xml_change.new_text)
     device.wait_for_text(text=js_change.new_text)

--- a/products/nativescript/tns.py
+++ b/products/nativescript/tns.py
@@ -526,7 +526,7 @@ class Tns(object):
         Get version of CLI
         :return: Version of the CLI as string
         """
-        return Tns.exec_command(command='--version').output.split(os.linesep)[-1]
+        return Tns.exec_command(command='--version')
 
     @staticmethod
     def kill():

--- a/tests/cli/create/test_init.py
+++ b/tests/cli/create/test_init.py
@@ -14,8 +14,6 @@ APP_PATH = os.path.join(Settings.TEST_RUN_HOME, APP_NAME)
 
 class InitAndInstallTests(TnsTest):
 
-    @classmethod
-
     def setUp(self):
         TnsTest.setUp(self)
         Folder.clean(APP_PATH)

--- a/tests/cli/create/test_init.py
+++ b/tests/cli/create/test_init.py
@@ -5,6 +5,7 @@ from core.enums.os_type import OSType
 from core.settings import Settings
 from core.utils.file_utils import Folder, File
 from core.utils.npm import Npm
+from data.templates import Template
 from products.nativescript.app import App
 from products.nativescript.tns import Tns
 

--- a/tests/cli/create/test_init.py
+++ b/tests/cli/create/test_init.py
@@ -5,19 +5,19 @@ from core.enums.os_type import OSType
 from core.settings import Settings
 from core.utils.file_utils import Folder, File
 from core.utils.npm import Npm
-from data.templates import Template
 from products.nativescript.app import App
 from products.nativescript.tns import Tns
 
 APP_NAME = Settings.AppName.DEFAULT
 APP_PATH = os.path.join(Settings.TEST_RUN_HOME, APP_NAME)
 
+
 class InitAndInstallTests(TnsTest):
 
     def setUp(self):
         TnsTest.setUp(self)
         Folder.clean(APP_PATH)
-        
+
     def test_201_init_defaults(self):
         Folder.create(APP_PATH)
         result = Tns.exec_command(command='init --force', cwd=APP_PATH)

--- a/tests/cli/create/test_init.py
+++ b/tests/cli/create/test_init.py
@@ -11,13 +11,10 @@ from products.nativescript.tns import Tns
 
 APP_NAME = Settings.AppName.DEFAULT
 APP_PATH = os.path.join(Settings.TEST_RUN_HOME, APP_NAME)
-TEMP_APP_PATH = os.path.join(Settings.TEST_RUN_HOME, Settings.AppName.WITH_DASH)
 
 class InitAndInstallTests(TnsTest):
 
     @classmethod
-    def setUpClass(cls):
-        Tns.create(app_name=Settings.AppName.WITH_DASH, template=Template.HELLO_WORLD_JS.local_package, update=False)
 
     def setUp(self):
         TnsTest.setUp(self)
@@ -85,7 +82,7 @@ class InitAndInstallTests(TnsTest):
         assert Folder.exists(os.path.join(APP_PATH, 'node_modules', 'gulp'))
 
         # Copy app folder and app resources
-        Folder.copy(source=os.path.join(cls.TEMP_APP_PATH, 'app'),
+        Folder.copy(source=os.path.join(Settings.TEST_RUN_HOME, 'assets', 'test-app-js-41', 'app'),
                     target=os.path.join(APP_PATH, 'app'))
 
         # Prepare project

--- a/tests/cli/create/test_init.py
+++ b/tests/cli/create/test_init.py
@@ -11,13 +11,13 @@ from products.nativescript.tns import Tns
 
 APP_NAME = Settings.AppName.DEFAULT
 APP_PATH = os.path.join(Settings.TEST_RUN_HOME, APP_NAME)
-TEMP_APP_PATH = os.path.join(Settings.TEST_RUN_HOME, Settings.AppName.APP_NAME)
+TEMP_APP_PATH = os.path.join(Settings.TEST_RUN_HOME, Settings.AppName.WITH_DASH)
 
 class InitAndInstallTests(TnsTest):
 
     @classmethod
     def setUpClass(cls):
-        Tns.create(app_name=Settings.AppName.APP_NAME, template=Template.HELLO_WORLD_JS.local_package, update=False)
+        Tns.create(app_name=Settings.AppName.WITH_DASH, template=Template.HELLO_WORLD_JS.local_package, update=False)
 
     def setUp(self):
         TnsTest.setUp(self)

--- a/tests/cli/create/test_init.py
+++ b/tests/cli/create/test_init.py
@@ -10,15 +10,18 @@ from products.nativescript.tns import Tns
 
 APP_NAME = Settings.AppName.DEFAULT
 APP_PATH = os.path.join(Settings.TEST_RUN_HOME, APP_NAME)
+TEMP_APP_PATH = os.path.join(Settings.TEST_RUN_HOME, Settings.AppName.APP_NAME)
 
-
-# noinspection PyMethodMayBeStatic
 class InitAndInstallTests(TnsTest):
+
+    @classmethod
+    def setUpClass(cls):
+        Tns.create(app_name=Settings.AppName.APP_NAME, template=Template.HELLO_WORLD_JS.local_package, update=False)
 
     def setUp(self):
         TnsTest.setUp(self)
         Folder.clean(APP_PATH)
-
+        
     def test_201_init_defaults(self):
         Folder.create(APP_PATH)
         result = Tns.exec_command(command='init --force', cwd=APP_PATH)
@@ -81,7 +84,7 @@ class InitAndInstallTests(TnsTest):
         assert Folder.exists(os.path.join(APP_PATH, 'node_modules', 'gulp'))
 
         # Copy app folder and app resources
-        Folder.copy(source=os.path.join(Settings.TEST_RUN_HOME, 'assets', 'template-min', 'app'),
+        Folder.copy(source=os.path.join(cls.TEMP_APP_PATH, 'app'),
                     target=os.path.join(APP_PATH, 'app'))
 
         # Prepare project

--- a/tests/cli/create/test_init.py
+++ b/tests/cli/create/test_init.py
@@ -80,7 +80,7 @@ class InitAndInstallTests(TnsTest):
         assert Folder.exists(os.path.join(APP_PATH, 'node_modules', 'gulp'))
 
         # Copy app folder and app resources
-        Folder.copy(source=os.path.join(Settings.TEST_RUN_HOME, 'assets', 'test-app-js-41', 'app'),
+        Folder.copy(source=os.path.join(Settings.TEST_RUN_HOME, 'assets', 'apps', 'test-app-js-41', 'app'),
                     target=os.path.join(APP_PATH, 'app'))
 
         # Prepare project

--- a/tests/cli/misc/version_tests.py
+++ b/tests/cli/misc/version_tests.py
@@ -2,6 +2,7 @@
 Test for `tns --version` command
 """
 import re
+import os
 
 from core.base_test.tns_test import TnsTest
 from products.nativescript.tns import Tns

--- a/tests/cli/misc/version_tests.py
+++ b/tests/cli/misc/version_tests.py
@@ -12,5 +12,9 @@ class VersionTests(TnsTest):
 
     def test_001_version(self):
         version = Tns.version()
-        match = re.compile("^\\d+\\.\\d+\\.\\d+(-\\S+)?$").match(version)
+        version_list = version.output.split(os.linesep)
+        for element in version_list:
+            match = re.compile("^\\d+\\.\\d+\\.\\d+(-\\S+)?$").match(element)
+            if match:
+                break
         assert match, "{0} is not a valid version.".format(version)


### PR DESCRIPTION
1. test_300_install_and_prepare fails because tries to copy app folder from  app in assets that does not exist anymore. Fix: copy app folder from other  test  app
2. test_001_version  fails because when you are with node8, version returns not only version string but warnings also and version.output.split(os.linesep)[-1] is not returning the wright string. Fix: make the main method Tns.version() return the whole output of the command. Assert the version string in the test
3. Preview tests without hmr and bundle often fail. According to logs wait for log timeout expires before the whole execution of the command is finished. Fix: increase timeout for non bundle cases.