### PR TITLE
fix: debug tests

### DIFF
--- a/core/utils/chrome/chrome.py
+++ b/core/utils/chrome/chrome.py
@@ -1,4 +1,5 @@
 import os
+from time import sleep
 
 from selenium import webdriver
 from webdriver_manager.chrome import ChromeDriverManager
@@ -28,6 +29,7 @@ class Chrome(object):
         self.implicitly_wait = implicitly_wait
         self.driver.implicitly_wait(self.implicitly_wait)
         self.driver.maximize_window()
+        self.focus()
         Log.info('Google Chrome started!')
 
     def open(self, url):
@@ -51,7 +53,13 @@ class Chrome(object):
             Process.kill(proc_name='chromedriver')
         Log.info('Kill Chrome browser!')
 
+    def focus(self):
+        self.driver.switch_to.window(self.driver.current_window_handle)
+        Log.info("Focus Chrome browser.")
+
     def get_absolute_center(self, element):
+        self.focus()
+        sleep(1)
         rel_x = element.location['x']
         rel_y = element.location['y']
         nav_panel_height = self.driver.execute_script('return window.outerHeight - window.innerHeight;')

--- a/core/utils/chrome/chrome.py
+++ b/core/utils/chrome/chrome.py
@@ -65,4 +65,9 @@ class Chrome(object):
         nav_panel_height = self.driver.execute_script('return window.outerHeight - window.innerHeight;')
         x = rel_x + element.size['width'] * 0.5
         y = rel_y + nav_panel_height + element.size['height'] * 0.5
+
+        # Hack to respect macOS default toolbar on top
+        if Settings.HOST_OS == OSType.OSX:
+            y = y + 25
+
         return x, y

--- a/core/utils/chrome/chrome.py
+++ b/core/utils/chrome/chrome.py
@@ -50,3 +50,11 @@ class Chrome(object):
                 Process.kill(proc_name="chrome", proc_cmdline=None)
             Process.kill(proc_name='chromedriver')
         Log.info('Kill Chrome browser!')
+
+    def get_absolute_center(self, element):
+        rel_x = element.location['x']
+        rel_y = element.location['y']
+        nav_panel_height = self.driver.execute_script('return window.outerHeight - window.innerHeight;')
+        x = rel_x + element.size['width'] * 0.5
+        y = rel_y + nav_panel_height + element.size['height'] * 0.5
+        return x, y

--- a/core/utils/chrome/chrome_dev_tools.py
+++ b/core/utils/chrome/chrome_dev_tools.py
@@ -1,5 +1,6 @@
 from time import sleep
 
+import pyautogui
 from aenum import IntEnum
 from selenium.webdriver import ActionChains
 from selenium.webdriver.common.by import By
@@ -176,9 +177,9 @@ class ChromeDevTools(object):
                 return line
         return None
 
-    def __find_span_by_text(self, text):
+    def find_span_by_text(self, text):
         line = self.__find_line_by_text(text=text)
-        spans = line.find_elements(By.CSS_SELECTOR, "span")
+        spans = line.find_elements(By.CSS_SELECTOR, "span[class='webkit-html-attribute-value']")
         for span in spans:
             if span.text == text:
                 return span
@@ -190,13 +191,15 @@ class ChromeDevTools(object):
         :param old_text: Old text.
         :param new_text: New text.
         """
-        span = self.__find_span_by_text(text=old_text)
+        span = self.find_span_by_text(text=old_text)
         assert span is not None, "Failed to find element with text " + old_text
-        actions = ActionChains(self.chrome.driver)
-        actions.double_click(span).perform()
-        self.chrome.driver.execute_script('arguments[0].innerHTML = "{0}";'.format(new_text), span)
-        actions.double_click(span).perform()
-        actions.send_keys(Keys.ENTER).perform()
+        x, y = self.chrome.get_absolute_center(span)
+        pyautogui.doubleClick(x, y)
+        sleep(0.5)
+        pyautogui.typewrite(new_text, interval=0.25)
+        sleep(0.5)
+        pyautogui.press('enter')
+        sleep(0.5)
         Log.info('Replace "{0}" with "{1}".'.format(old_text, new_text))
 
     def doubleclick_line(self, text):

--- a/core/utils/chrome/chrome_dev_tools.py
+++ b/core/utils/chrome/chrome_dev_tools.py
@@ -191,6 +191,7 @@ class ChromeDevTools(object):
         :param old_text: Old text.
         :param new_text: New text.
         """
+        self.chrome.driver.switch_to_window(self.chrome.driver.current_window_handle)
         span = self.find_span_by_text(text=old_text)
         assert span is not None, "Failed to find element with text " + old_text
         x, y = self.chrome.get_absolute_center(span)

--- a/core/utils/chrome/chrome_dev_tools.py
+++ b/core/utils/chrome/chrome_dev_tools.py
@@ -125,14 +125,16 @@ class ChromeDevTools(object):
         :param file_name: Name of file.
         """
         self.chrome.focus()
+        sleep(1)
 
         # Double click to set focus
         panel = self.chrome.driver.find_element(By.ID, "sources-panel-sources-view")
         x, y = self.chrome.get_absolute_center(panel)
-        pyautogui.doubleClick(x, y)
+        pyautogui.click(x, y, 2, 0.05)
         sleep(1)
         if Settings.HOST_OS == OSType.OSX:
             pyautogui.hotkey('command', 'p')
+            # ActionChains(self.chrome.driver).send_keys(Keys.COMMAND, "p").perform()
         else:
             pyautogui.hotkey('ctrl', 'p')
         sleep(1)
@@ -201,6 +203,8 @@ class ChromeDevTools(object):
         span = self.__find_span_by_text(text=old_text)
         assert span is not None, "Failed to find element with text " + old_text
         x, y = self.chrome.get_absolute_center(span)
+        pyautogui.click(x, y, clicks=3, interval=0.1)
+        sleep(0.5)
         pyautogui.doubleClick(x, y)
         sleep(0.5)
         pyautogui.typewrite(new_text, interval=0.25)

--- a/core/utils/chrome/chrome_dev_tools.py
+++ b/core/utils/chrome/chrome_dev_tools.py
@@ -35,6 +35,7 @@ class ChromeDevTools(object):
     def __init__(self, chrome, platform, tab=None):
         # Start Chrome and open debug url
         self.chrome = chrome
+        self.chrome.focus()
         debug_url = 'chrome-devtools://devtools/bundled/inspector.html'
         port = None
         if platform == Platform.ANDROID:
@@ -123,11 +124,17 @@ class ChromeDevTools(object):
         Open file on Sources tab of Chrome Dev Tools.
         :param file_name: Name of file.
         """
-        actions = ActionChains(self.chrome.driver)
+        self.chrome.focus()
+
+        # Double click to set focus
+        panel = self.chrome.driver.find_element(By.ID, "sources-panel-sources-view")
+        x, y = self.chrome.get_absolute_center(panel)
+        pyautogui.doubleClick(x, y)
+        sleep(1)
         if Settings.HOST_OS == OSType.OSX:
-            actions.send_keys(Keys.COMMAND, 'p').perform()
+            pyautogui.hotkey('command', 'p')
         else:
-            actions.send_keys(Keys.CONTROL, 'p').perform()
+            pyautogui.hotkey('ctrl', 'p')
         sleep(1)
         shadow_dom_element = self.chrome.driver.find_element(By.CSS_SELECTOR,
                                                              "div[style='z-index: 3000;'][class='vbox flex-auto']")
@@ -177,7 +184,7 @@ class ChromeDevTools(object):
                 return line
         return None
 
-    def find_span_by_text(self, text):
+    def __find_span_by_text(self, text):
         line = self.__find_line_by_text(text=text)
         spans = line.find_elements(By.CSS_SELECTOR, "span[class='webkit-html-attribute-value']")
         for span in spans:
@@ -191,8 +198,7 @@ class ChromeDevTools(object):
         :param old_text: Old text.
         :param new_text: New text.
         """
-        self.chrome.driver.switch_to_window(self.chrome.driver.current_window_handle)
-        span = self.find_span_by_text(text=old_text)
+        span = self.__find_span_by_text(text=old_text)
         assert span is not None, "Failed to find element with text " + old_text
         x, y = self.chrome.get_absolute_center(span)
         pyautogui.doubleClick(x, y)
@@ -210,8 +216,8 @@ class ChromeDevTools(object):
         """
         line = self.__find_line_by_text(text=text)
         assert line is not None, "Failed to find line with text " + text
-        actions = ActionChains(self.chrome.driver)
-        actions.double_click(line).perform()
+        x, y = self.chrome.get_absolute_center(line)
+        pyautogui.doubleClick(x, y)
         Log.info('Double click line with text "{0}".'.format(text))
 
     def __clean_console(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ subprocess32>=3.5.3
 requests>=2.21.0
 pytz>=2018.9
 Appium-Python-Client>=0.28
+pyautogui==0.9.39

--- a/requirements_darwin.txt
+++ b/requirements_darwin.txt
@@ -19,3 +19,4 @@ subprocess32>=3.5.3
 requests>=2.21.0
 pytz>=2018.9
 Appium-Python-Client>=0.28
+pyautogui==0.9.39

--- a/tests/cli/debug/test_debug_js.py
+++ b/tests/cli/debug/test_debug_js.py
@@ -288,6 +288,7 @@ class DebugJSTests(TnsRunTest):
         assert "Test Debug!" in tns_logs, 'Console log messages not available in CLI output.' + os.linesep + tns_logs
 
         # Verify debug is working (covers https://github.com/NativeScript/nativescript-cli/issues/2831)
+        self.dev_tools.open_tab(ChromeDevToolsTabs.SOURCES)
         self.dev_tools.load_source_file("main-view-model.js")
         self.dev_tools.breakpoint(17)
         device.click(text="TAP", case_sensitive=True)


### PR DESCRIPTION
**Issue Reason**
In latest chrome/driver `actions.double_click(span).perform()` do not cause real double click.

**Impact**
Result is we fail to edit text in elements tab -> failing tests.

**The Fix**
We use `pyautogui` and do real clicks.
In order to do real clicks we need absolute coordiantes of elements so `Chrome.get_absolute_center()` is implemented.

**Notes**
We use strict version of `pyautogui==0.9.39` because as of `pyautogui==0.9.40` it is not compatible with Python 2.