### PR TITLE
chore: updates in app update method

### DIFF
--- a/core_tests/e2e/products/test_tns.py
+++ b/core_tests/e2e/products/test_tns.py
@@ -18,7 +18,7 @@ class TnsSmokeTests(TnsRunTest):
     def setUpClass(cls):
         run_common.prepare(clone_templates=True, install_ng_cli=False)
         TnsRunTest.setUpClass()
-        Tns.create(app_name=APP_NAME, template=Template.HELLO_WORLD_JS.local_package, update=False)
+        Tns.create(app_name=APP_NAME, template=Template.HELLO_WORLD_JS.local_package, update=True)
         Tns.platform_add_android(app_name=APP_NAME, framework_path=Settings.Android.FRAMEWORK_PATH)
         if Settings.HOST_OS is OSType.OSX:
             Tns.platform_add_ios(app_name=APP_NAME, framework_path=Settings.IOS.FRAMEWORK_PATH)

--- a/products/nativescript/app.py
+++ b/products/nativescript/app.py
@@ -79,4 +79,4 @@ class App(object):
 
         if vue and App.is_dependency(app_name=app_name, dependency='nativescript-vue'):
             Npm.uninstall(package='nativescript-vue', option='--save', folder=app_path)
-            Npm.install(package='nativescript-vue@latest', option='--save --save-exact', folder=app_path)
+            Npm.install(package='nativescript-vue@next', option='--save --save-exact', folder=app_path)

--- a/products/nativescript/app.py
+++ b/products/nativescript/app.py
@@ -72,7 +72,8 @@ class App(object):
             Folder.clean(os.path.join(app_name, 'hooks'))
             Folder.clean(os.path.join(app_name, 'node_modules'))
             Npm.install(folder=app_path)
-            update_script = os.path.join(modules_path, '.bin', 'update-ns-webpack') + ' --deps --configs'
+            path_script = '"' + os.path.join(modules_path, '.bin', 'update-ns-webpack') + '"'
+            update_script = path_script + ' --deps --configs'
             result = run(cmd=update_script, log_level=logging.INFO)
             assert 'Updating dev dependencies...' in result.output, 'Webpack dependencies not updated.'
             assert 'Updating configuration files...' in result.output, 'Webpack configs not updated.'

--- a/products/nativescript/app.py
+++ b/products/nativescript/app.py
@@ -45,7 +45,7 @@ class App(object):
         Npm.install(package='{0}@{1}'.format(dependency, version), option='--save-dev --save-exact', folder=app_path)
 
     @staticmethod
-    def update(app_name, modules=True, angular=True, typescript=True, web_pack=True, vue=True):
+    def update(app_name, modules=True, angular=True, typescript=False, web_pack=True, vue=True):
         app_path = os.path.join(Settings.TEST_RUN_HOME, app_name)
         modules_path = os.path.join(app_path, 'node_modules')
         if modules and App.is_dependency(app_name=app_name, dependency='tns-core-modules'):


### PR DESCRIPTION
1. Update nativescript-vue plugin to next version - the next version is compatible with nativescript@6.0
2. We do not need to update nativescript-dev-typscript by default anymore - set it to False
3. Fix path to webpack update script for projects with space in the name
4. Set update of app in core tests to True, because we cannot build with older versions of webpack