### PR TITLE
fix: skip no space left on device test

### DIFF
--- a/tests/cli/run/tests/run_tests.py
+++ b/tests/cli/run/tests/run_tests.py
@@ -743,6 +743,7 @@ class TnsRunJSTests(TnsRunTest):
         app_name = '"' + self.app_name_space + '"'
         run_hello_world_js_ts(app_name, Platform.ANDROID, self.emu, just_launch=True)
 
+    @unittest.skip("Skip this test due to emulator api28 ui crashing when no space left on device")
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, '`shell cp -r` fails on emulators on Linux and Win.')
     def test_365_tns_run_android_should_respect_adb_errors(self):
         """


### PR DESCRIPTION
Temporary skip test test_365_tns_run_android_should_respect_adb_errors. On emulator Api28 the UI is crashing  when no space left on device and we try to deploy.