### PR TITLE
fix: ImageUtils.get_text() on python 3

### DIFF
--- a/core/utils/image_utils.py
+++ b/core/utils/image_utils.py
@@ -144,7 +144,10 @@ class ImageUtils(object):
                     temp_text = "".join([s for s in temp_text.splitlines(True) if s.strip()])
                     temp_text = temp_text.encode(encoding='utf-8', errors='ignore')
                     if temp_text not in text:
-                        text = text + os.linesep + temp_text
+                        if Settings.PYTHON_VERSION < 3:
+                            text = text + os.linesep + temp_text
+                        else:
+                            text = text + str.encode(os.linesep) + temp_text
         if Settings.PYTHON_VERSION < 3:
             return text
         else:

--- a/products/nativescript/preview_helpers.py
+++ b/products/nativescript/preview_helpers.py
@@ -105,11 +105,11 @@ class Preview(object):
         Log.info('Open "{0}" on {1}.'.format(url, device.name))
         if device.type == DeviceType.EMU or device.type == DeviceType.ANDROID:
             cmd = 'shell am start -a android.intent.action.VIEW -d "{0}" org.nativescript.preview'.format(url)
-            result = Adb.run_adb_command(command=cmd, device_id=device.id)
-            assert 'error' not in result.output
+            output = Adb.run_adb_command(command=cmd, device_id=device.id).output
+            assert 'error' not in output, 'Failed to open URL!' + os.linesep + 'Error:' + os.linesep + output
         elif device.type == DeviceType.SIM:
-            result = Simctl.run_simctl_command(command='openurl {0} {1}.'.format(device.id, url))
-            assert 'error' not in result.output
+            output = Simctl.run_simctl_command(command='openurl {0} {1}.'.format(device.id, url)).output
+            assert 'error' not in output, 'Failed to open URL!' + os.linesep + 'Error:' + os.linesep + output
         else:
             raise NotImplementedError('Open url not implemented for real iOS devices.')
 


### PR DESCRIPTION
I notices following error when execute tests on Windows machiens with Python3:
```
Traceback (most recent call last):
  File "C:\Python37\lib\unittest\case.py", line 59, in testPartExecutor
    yield
  File "C:\Python37\lib\unittest\case.py", line 615, in run
    testMethod()
  File "C:\Jenkins\workspace\master-cli-vue-windows\tests\vue\test_vue_master_detail_run.py", line 49, in test_100_run_android_bundle
    sync_master_detail_vue(self.app_name, Platform.ANDROID, self.emu)
  File "C:\Jenkins\workspace\master-cli-vue-windows\data\sync\master_detail_vue.py", line 37, in sync_master_detail_vue
    device.wait_for_text(text="Ford KA")
  File "C:\Jenkins\workspace\master-cli-vue-windows\core\utils\device\device.py", line 99, in wait_for_text
    text = self.get_text()
  File "C:\Jenkins\workspace\master-cli-vue-windows\core\utils\device\device.py", line 75, in get_text
    text = ImageUtils.get_text(image_path=actual_image_path)
  File "C:\Jenkins\workspace\master-cli-vue-windows\core\utils\image_utils.py", line 147, in get_text
    text = text + os.linesep + temp_text
TypeError: can't concat str to bytes
```

This PR should solve it.

Details:
In Python3 `os.linesep` is str, while `text` and `temp_text` are bytes and concatenation fails.