### PR TITLE
fix: check ios simulator availability

### DIFF
--- a/core/utils/device/simctl.py
+++ b/core/utils/device/simctl.py
@@ -30,7 +30,7 @@ class Simctl(object):
     def start(simulator_info):
         if simulator_info.id is not None:
             Simctl.run_simctl_command(command='boot {0}'.format(simulator_info.id))
-            Simctl.wait_until_boot(simulator_info)
+            assert Simctl.wait_until_boot(simulator_info), 'Failed to boot "{0}".'.format(simulator_info.id)
             return simulator_info
         else:
             raise Exception('Can not boot iOS simulator if udid is not specified!')
@@ -84,7 +84,7 @@ class Simctl(object):
             device_key = 'com.apple.CoreSimulator.SimRuntime.{0}'.format(placeholder_dash)
         sims = devices[device_key]
         for sim in sims:
-            if sim['name'] == simulator_info.name:
+            if sim['name'] == simulator_info.name and sim['availability'] == u'(available)':
                 simulator_info.id = str(sim['udid'])
                 return simulator_info
         return False

--- a/core_tests/e2e/core/test_devices.py
+++ b/core_tests/e2e/core/test_devices.py
@@ -1,5 +1,8 @@
+import unittest
+
 from core.base_test.tns_test import TnsTest
 from core.enums.device_type import DeviceType
+from core.enums.os_type import OSType
 from core.settings import Settings
 from core.utils.device.device_manager import DeviceManager
 from core.utils.device.emulator_info import EmulatorInfo
@@ -30,7 +33,6 @@ class DeviceTests(TnsTest):
         assert emu.id == Settings.Emulators.DEFAULT.emu_id, 'Emulator should be booted on specified port.'
         assert emu.name == Settings.Emulators.DEFAULT.avd, 'Device name should match avd name from settings.'
         assert emu.version == Settings.Emulators.DEFAULT.os_version, 'Device version should match os_version.'
-        assert emu.type == DeviceType.EMU
 
         # Verify Emulator.is_running returns true if emu is running
         valid_emu = EmulatorInfo(avd=Settings.Emulators.DEFAULT.avd,
@@ -55,6 +57,15 @@ class DeviceTests(TnsTest):
 
         is_running = DeviceManager.Emulator.is_running(wrong_version_emu)
         assert is_running is False, 'Emulator.is_running() should return false if os_version is different.'
+
+    @unittest.skipIf(Settings.HOST_OS is not OSType.OSX, 'iOS tests can be executed only on macOS.')
+    def test_002_simulator(self):
+        assert DeviceManager.Simulator.is_available(Settings.Simulators.DEFAULT)
+        sim = DeviceManager.Simulator.ensure_available(Settings.Simulators.DEFAULT)
+        assert sim.type == DeviceType.SIM, 'Device should be of type DeviceType.EMU'
+        assert sim.id is not None, 'Sim ID should not be none.'
+        assert sim.name == Settings.Simulators.DEFAULT.name, 'Device name should match avd name from settings.'
+        assert sim.version == Settings.Simulators.DEFAULT.sdk, 'Device version should match os_version.'
 
     def test_100_detect_available_emulators(self):
         # Verify Emulator.is_available() return correct result

--- a/core_tests/e2e/core/test_devices.py
+++ b/core_tests/e2e/core/test_devices.py
@@ -61,11 +61,6 @@ class DeviceTests(TnsTest):
     @unittest.skipIf(Settings.HOST_OS is not OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_002_simulator(self):
         assert DeviceManager.Simulator.is_available(Settings.Simulators.DEFAULT)
-        sim = DeviceManager.Simulator.ensure_available(Settings.Simulators.DEFAULT)
-        assert sim.type == DeviceType.SIM, 'Device should be of type DeviceType.EMU'
-        assert sim.id is not None, 'Sim ID should not be none.'
-        assert sim.name == Settings.Simulators.DEFAULT.name, 'Device name should match avd name from settings.'
-        assert sim.version == Settings.Simulators.DEFAULT.sdk, 'Device version should match os_version.'
 
     def test_100_detect_available_emulators(self):
         # Verify Emulator.is_available() return correct result


### PR DESCRIPTION
Problem 1:
- Even if `Simctl.wait_until_boot(simulator_info)` return false, we do not assert it and say iOS Simulator is OK

Problem 2:
- When update Xcode 10.0 to Xcode 10.2 then SDK 12.0 is removed and SDK 12.2 is added
- iOS 12.0 Simulator is still returned by `scrun simctl` but it can not be used, because it is with availability `unavailable`
- In the case above Simctl.is_available() returns `true`

Fixes:
- check ios simulator really available 
- check if ios simulator booted in Simctl.start()