### PR TITLE
fix: replace applescript with device.click() method in preview tests

### DIFF
--- a/data/sync/hello_world_js.py
+++ b/data/sync/hello_world_js.py
@@ -151,9 +151,9 @@ def __sync_hello_world_js_ts(app_type, app_name, platform, device,
     device.screen_match(expected_image=initial_state, tolerance=1.0, timeout=30)
 
 
-def preview_hello_world_js_ts(app_name, platform, device, bundle=True, hmr=True, instrumented=False):
+def preview_hello_world_js_ts(app_name, platform, device, bundle=True, hmr=True, instrumented=False, click_open_alert=False):
     result = Preview.run_app(app_name=app_name, bundle=bundle, hmr=hmr, platform=platform,
-                             device=device, instrumented=instrumented)
+                             device=device, instrumented=instrumented, click_open_alert=click_open_alert)
 
     # Verify app looks properly
     device.wait_for_text(text=Changes.JSHelloWord.JS.old_text, timeout=60, retry_delay=5)
@@ -164,9 +164,9 @@ def preview_hello_world_js_ts(app_name, platform, device, bundle=True, hmr=True,
     return result
 
 
-def preview_sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=True, hmr=True, instrumented=False):
+def preview_sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=True, hmr=True, instrumented=False, click_open_alert=False):
     result = preview_hello_world_js_ts(app_name=app_name, platform=platform, device=device, bundle=bundle, hmr=hmr,
-                                       instrumented=instrumented)
+                                       instrumented=instrumented, click_open_alert=click_open_alert)
 
     blue_count = device.get_pixels_by_color(color=Colors.LIGHT_BLUE)
     # Set changes

--- a/data/sync/hello_world_js.py
+++ b/data/sync/hello_world_js.py
@@ -151,7 +151,8 @@ def __sync_hello_world_js_ts(app_type, app_name, platform, device,
     device.screen_match(expected_image=initial_state, tolerance=1.0, timeout=30)
 
 
-def preview_hello_world_js_ts(app_name, platform, device, bundle=True, hmr=True, instrumented=False, click_open_alert=False):
+def preview_hello_world_js_ts(app_name, platform, device, bundle=True, hmr=True, instrumented=False,
+                              click_open_alert=False):
     result = Preview.run_app(app_name=app_name, bundle=bundle, hmr=hmr, platform=platform,
                              device=device, instrumented=instrumented, click_open_alert=click_open_alert)
 
@@ -164,7 +165,8 @@ def preview_hello_world_js_ts(app_name, platform, device, bundle=True, hmr=True,
     return result
 
 
-def preview_sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=True, hmr=True, instrumented=False, click_open_alert=False):
+def preview_sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=True, hmr=True, instrumented=False,
+                                   click_open_alert=False):
     result = preview_hello_world_js_ts(app_name=app_name, platform=platform, device=device, bundle=bundle, hmr=hmr,
                                        instrumented=instrumented, click_open_alert=click_open_alert)
 

--- a/data/sync/hello_world_ng.py
+++ b/data/sync/hello_world_ng.py
@@ -102,7 +102,7 @@ def sync_hello_world_ng(app_name, platform, device, bundle=True, uglify=False, a
     device.screen_match(expected_image=initial_state, tolerance=1.0, timeout=30)
 
 
-def preview_hello_world_ng(app_name, platform, device, bundle=False, hmr=False, instrumented=False, 
+def preview_hello_world_ng(app_name, platform, device, bundle=False, hmr=False, instrumented=False,
                            click_open_alert=False):
     result = Preview.run_app(app_name=app_name, bundle=bundle, hmr=hmr, platform=platform,
                              device=device, instrumented=instrumented, click_open_alert=click_open_alert)

--- a/data/sync/hello_world_ng.py
+++ b/data/sync/hello_world_ng.py
@@ -102,9 +102,9 @@ def sync_hello_world_ng(app_name, platform, device, bundle=True, uglify=False, a
     device.screen_match(expected_image=initial_state, tolerance=1.0, timeout=30)
 
 
-def preview_hello_world_ng(app_name, platform, device, bundle=False, hmr=False, instrumented=False):
+def preview_hello_world_ng(app_name, platform, device, bundle=False, hmr=False, instrumented=False, click_open_alert=False):
     result = Preview.run_app(app_name=app_name, bundle=bundle, hmr=hmr, platform=platform,
-                             device=device, instrumented=instrumented)
+                             device=device, instrumented=instrumented, click_open_alert=click_open_alert)
 
     # Verify app looks properly
     device.wait_for_text(text=Changes.NGHelloWorld.TS.old_text)
@@ -114,9 +114,9 @@ def preview_hello_world_ng(app_name, platform, device, bundle=False, hmr=False, 
     return result
 
 
-def preview_sync_hello_world_ng(app_name, platform, device, bundle=True, hmr=True, instrumented=False):
+def preview_sync_hello_world_ng(app_name, platform, device, bundle=True, hmr=True, instrumented=False, click_open_alert=False):
     result = preview_hello_world_ng(app_name=app_name, platform=platform, device=device, bundle=bundle, hmr=hmr,
-                                    instrumented=instrumented)
+                                    instrumented=instrumented, click_open_alert=click_open_alert)
 
     # Edit TS file and verify changes are applied
     Sync.replace(app_name=app_name, change_set=Changes.NGHelloWorld.TS)

--- a/data/sync/hello_world_ng.py
+++ b/data/sync/hello_world_ng.py
@@ -102,7 +102,8 @@ def sync_hello_world_ng(app_name, platform, device, bundle=True, uglify=False, a
     device.screen_match(expected_image=initial_state, tolerance=1.0, timeout=30)
 
 
-def preview_hello_world_ng(app_name, platform, device, bundle=False, hmr=False, instrumented=False, click_open_alert=False):
+def preview_hello_world_ng(app_name, platform, device, bundle=False, hmr=False, instrumented=False, 
+                           click_open_alert=False):
     result = Preview.run_app(app_name=app_name, bundle=bundle, hmr=hmr, platform=platform,
                              device=device, instrumented=instrumented, click_open_alert=click_open_alert)
 
@@ -114,7 +115,8 @@ def preview_hello_world_ng(app_name, platform, device, bundle=False, hmr=False, 
     return result
 
 
-def preview_sync_hello_world_ng(app_name, platform, device, bundle=True, hmr=True, instrumented=False, click_open_alert=False):
+def preview_sync_hello_world_ng(app_name, platform, device, bundle=True, hmr=True, instrumented=False,
+                                click_open_alert=False):
     result = preview_hello_world_ng(app_name=app_name, platform=platform, device=device, bundle=bundle, hmr=hmr,
                                     instrumented=instrumented, click_open_alert=click_open_alert)
 

--- a/products/nativescript/preview_helpers.py
+++ b/products/nativescript/preview_helpers.py
@@ -6,6 +6,8 @@ from core.enums.device_type import DeviceType
 from core.enums.platform_type import Platform
 from core.enums.os_type import OSType
 from core.log.log import Log
+from products.nativescript.tns import Tns
+from products.nativescript.tns_logs import TnsLogs
 from core.settings import Settings
 from core.settings.Settings import TEST_SUT_HOME, TEST_RUN_HOME
 from core.utils.device.adb import Adb
@@ -14,8 +16,6 @@ from core.utils.file_utils import File
 from core.utils.run import run
 if Settings.HOST_OS is OSType.OSX:
     from core.utils.device.simauto import SimAuto
-from products.nativescript.tns import Tns
-from products.nativescript.tns_logs import TnsLogs
 
 
 class Preview(object):

--- a/products/nativescript/preview_helpers.py
+++ b/products/nativescript/preview_helpers.py
@@ -9,11 +9,13 @@ from core.settings import Settings
 from core.settings.Settings import TEST_SUT_HOME, TEST_RUN_HOME
 from core.utils.device.adb import Adb
 from core.utils.device.simctl import Simctl
-from core.utils.device.simauto import SimAuto
 from core.utils.file_utils import File
 from core.utils.run import run
 from products.nativescript.tns import Tns
 from products.nativescript.tns_logs import TnsLogs
+
+if Settings.HOST_OS is OSType.OSX:
+    from core.utils.device.simauto import SimAuto
 
 
 class Preview(object):

--- a/products/nativescript/preview_helpers.py
+++ b/products/nativescript/preview_helpers.py
@@ -12,11 +12,10 @@ from core.utils.device.adb import Adb
 from core.utils.device.simctl import Simctl
 from core.utils.file_utils import File
 from core.utils.run import run
-from products.nativescript.tns import Tns
-from products.nativescript.tns_logs import TnsLogs
-
 if Settings.HOST_OS is OSType.OSX:
     from core.utils.device.simauto import SimAuto
+from products.nativescript.tns import Tns
+from products.nativescript.tns_logs import TnsLogs
 
 
 class Preview(object):

--- a/products/nativescript/preview_helpers.py
+++ b/products/nativescript/preview_helpers.py
@@ -4,6 +4,7 @@ import time
 
 from core.enums.device_type import DeviceType
 from core.enums.platform_type import Platform
+from core.enums.os_type import OSType
 from core.log.log import Log
 from core.settings import Settings
 from core.settings.Settings import TEST_SUT_HOME, TEST_RUN_HOME

--- a/products/nativescript/preview_helpers.py
+++ b/products/nativescript/preview_helpers.py
@@ -123,7 +123,7 @@ class Preview(object):
         run(command)
 
     @staticmethod
-    def run_app(app_name, platform, device, bundle=False, hmr=False, instrumented=False, click_open_alert=False):
+    def run_app(app_name, platform, device, bundle=True, hmr=True, instrumented=False, click_open_alert=False):
         result = Tns.preview(app_name=app_name, bundle=bundle, hmr=hmr)
 
         # Read the log and extract the url to load the app on emulator

--- a/products/nativescript/preview_helpers.py
+++ b/products/nativescript/preview_helpers.py
@@ -9,6 +9,7 @@ from core.settings import Settings
 from core.settings.Settings import TEST_SUT_HOME, TEST_RUN_HOME
 from core.utils.device.adb import Adb
 from core.utils.device.simctl import Simctl
+from core.utils.device.simauto import SimAuto
 from core.utils.file_utils import File
 from core.utils.run import run
 from products.nativescript.tns import Tns
@@ -122,7 +123,7 @@ class Preview(object):
         run(command)
 
     @staticmethod
-    def run_app(app_name, platform, device, bundle=True, hmr=True, instrumented=False, click_open_alert=False):
+    def run_app(app_name, platform, device, bundle=False, hmr=False, instrumented=False, click_open_alert=False):
         result = Tns.preview(app_name=app_name, bundle=bundle, hmr=hmr)
 
         # Read the log and extract the url to load the app on emulator
@@ -132,11 +133,9 @@ class Preview(object):
         # When you run preview on ios simulator on first run confirmation dialog is shown.
         if device.type == DeviceType.SIM:
             if click_open_alert is True:
-                time.sleep(5)
-                device.click("Open")
-            else:
-                time.sleep(2)
-                Preview.dismiss_simulator_alert()
+                if SimAuto.find(device_info=device, text="Open"):
+                    time.sleep(5)
+                    device.click("Open")
 
         # Verify logs
         strings = TnsLogs.preview_initial_messages(platform=platform, hmr=hmr, bundle=bundle, instrumented=instrumented)

--- a/products/nativescript/preview_helpers.py
+++ b/products/nativescript/preview_helpers.py
@@ -2,12 +2,12 @@ import os
 import re
 import time
 
+from products.nativescript.tns import Tns
+from products.nativescript.tns_logs import TnsLogs
 from core.enums.device_type import DeviceType
 from core.enums.platform_type import Platform
 from core.enums.os_type import OSType
 from core.log.log import Log
-from products.nativescript.tns import Tns
-from products.nativescript.tns_logs import TnsLogs
 from core.settings import Settings
 from core.settings.Settings import TEST_SUT_HOME, TEST_RUN_HOME
 from core.utils.device.adb import Adb

--- a/tests/cli/preview/templates/hello_word_js_tests.py
+++ b/tests/cli/preview/templates/hello_word_js_tests.py
@@ -69,7 +69,7 @@ class PreviewJSTests(TnsPreviewJSTests):
     def test_100_preview_ios(self):
         """Preview project on simulator. Make valid changes in JS, CSS and XML"""
         preview_sync_hello_world_js_ts(app_type=AppType.JS, app_name=self.app_name, platform=Platform.IOS,
-                                       device=self.sim)
+                                       device=self.sim, click_open_alert=True)
 
     def test_205_preview_android_no_hmr(self):
         """Preview project on emulator with --no-hmr. Make valid changes in JS, CSS and XML"""


### PR DESCRIPTION
Using AppleScript to dismiss simulator alert is a bit flaky. Try making preview test for iOS more stable using device.click() method to dismiss the alert