### PR TITLE
fix: add additional assert in run clean tests

### DIFF
--- a/tests/cli/run/tests/run_tests.py
+++ b/tests/cli/run/tests/run_tests.py
@@ -491,7 +491,7 @@ class TnsRunJSTests(TnsRunTest):
         # Verify run --clean without changes skip prepare and rebuild of native project
 
         result = Tns.run_android(app_name=self.app_name, verify=True, device=self.emu.id, clean=True, just_launch=True)
-        strings = ['Preparing project', 'Building project', 'Gradle clean']
+        strings = ['Preparing project', 'Building project', 'Gradle clean', 'Successfully synced application']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=120)
 
         self.emu.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
@@ -525,7 +525,7 @@ class TnsRunJSTests(TnsRunTest):
 
         # Verify run --clean without changes rebuilds native project
         result = Tns.run_ios(app_name=self.app_name, verify=True, device=self.sim.id, clean=True, just_launch=True)
-        strings = ['Building project', 'Xcode build...']
+        strings = ['Building project', 'Xcode build...', 'Successfully synced application']
         not_existing_strings = ['Successfully transferred bundle.js on device',
                                 'Successfully transferred package.json on device',
                                 'Successfully transferred vendor.js on device']

--- a/tests/cli/run/tests/run_tests.py
+++ b/tests/cli/run/tests/run_tests.py
@@ -526,11 +526,7 @@ class TnsRunJSTests(TnsRunTest):
         # Verify run --clean without changes rebuilds native project
         result = Tns.run_ios(app_name=self.app_name, verify=True, device=self.sim.id, clean=True, just_launch=True)
         strings = ['Building project', 'Xcode build...', 'Successfully synced application']
-        not_existing_strings = ['Successfully transferred bundle.js on device',
-                                'Successfully transferred package.json on device',
-                                'Successfully transferred vendor.js on device']
-        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
-                             not_existing_string_list=not_existing_strings, timeout=120)
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=120)
         self.sim.wait_for_text(text=Changes.JSHelloWord.XML.old_text)
 
         # Verify if changes are applied and then run with clean it will apply changes on device


### PR DESCRIPTION
Run with clean often fails with error that concurrent build is running on that machine. It looks like the asserts we do, do not wait enough for the previous build to finish. The fix is to add assert that the app is synced and after that run the second build.