### PR TITLE
fix: hack to respect macOS and Linux default toolbar on top

### DIFF
--- a/core/utils/chrome/chrome.py
+++ b/core/utils/chrome/chrome.py
@@ -66,8 +66,8 @@ class Chrome(object):
         x = rel_x + element.size['width'] * 0.5
         y = rel_y + nav_panel_height + element.size['height'] * 0.5
 
-        # Hack to respect macOS default toolbar on top
-        if Settings.HOST_OS == OSType.OSX:
+        # Hack to respect macOS and Linux default toolbar on top
+        if Settings.HOST_OS != OSType.WINDOWS:
             y = y + 25
 
         return x, y


### PR DESCRIPTION
On linux machines we also have 25px bar on top.