### PR TITLE
feat: support api29 and xcode 11

### DIFF
--- a/core/base_test/tns_test.py
+++ b/core/base_test/tns_test.py
@@ -49,7 +49,10 @@ class TnsTest(unittest.TestCase):
             if Xcode.get_version() < 10:
                 Settings.Simulators.DEFAULT = Settings.Simulators.SIM_IOS11
             else:
-                Settings.Simulators.DEFAULT = Settings.Simulators.SIM_IOS12
+                if Xcode.get_version() < 11:
+                    Settings.Simulators.DEFAULT = Settings.Simulators.SIM_IOS12
+                else:
+                    Settings.Simulators.DEFAULT = Settings.Simulators.SIM_IOS13
 
     def setUp(self):
         TestContext.TEST_NAME = self._testMethodName

--- a/core/settings/Settings.py
+++ b/core/settings/Settings.py
@@ -30,7 +30,7 @@ def get_env():
     elif 'rc' in env:
         return EnvironmentType.RC
     elif 'pr' in env:
-        return EnvironmentType.LIVE
+        return EnvironmentType.PR
     else:
         return EnvironmentType.LIVE
 
@@ -111,6 +111,9 @@ class Packages(object):
     TYPESCRIPT = resolve_package(name='nativescript-dev-typescript', variable='nativescript_dev_typescript')
     SASS = resolve_package(name='nativescript-dev-sass', variable='nativescript_dev_sass')
 
+    # Templates branch
+    TEMPLATES_BRANCH = os.environ.get('templates_branch', 'master')
+
 
 # noinspection SpellCheckingInspection
 class Android(object):
@@ -151,6 +154,9 @@ class Emulators(object):
                               emu_id='emulator-5564')
     EMU_API_28 = EmulatorInfo(avd=os.environ.get('EMU_API_28', 'Emulator-Api28-Google'), os_version=9.0, port='5566',
                               emu_id='emulator-5566')
+    EMU_API_29 = EmulatorInfo(avd=os.environ.get('EMU_API_29', 'Emulator-Api29-Google'), os_version=10.0, port='5568',
+                              emu_id='emulator-5568')
+
     DEFAULT = EMU_API_23
 
 
@@ -158,7 +164,8 @@ class Simulators(object):
     SIM_IOS10 = SimulatorInfo(name=os.environ.get('SIM_IOS10', 'iPhone7_10'), device_type='iPhone 7', sdk=10.0)
     SIM_IOS11 = SimulatorInfo(name=os.environ.get('SIM_IOS11', 'iPhone7_11'), device_type='iPhone 7', sdk=11.2)
     SIM_IOS12 = SimulatorInfo(name=os.environ.get('SIM_IOS12', 'iPhoneXR_12'), device_type='iPhone XR', sdk=12.0)
-    DEFAULT = SIM_IOS11
+    SIM_IOS13 = SimulatorInfo(name=os.environ.get('SIM_IOS13', 'iPhoneXR_13'), device_type='iPhone XR', sdk=13.0)
+    DEFAULT = SIM_IOS12
 
 
 class AppName(object):

--- a/core/utils/device/adb.py
+++ b/core/utils/device/adb.py
@@ -97,11 +97,11 @@ class Adb(object):
         :return: True if running, False if not running.
         """
         if Settings.HOST_OS is OSType.WINDOWS:
-            command = "shell dumpsys window windows | findstr mCurrentFocus"
+            command = "shell dumpsys window windows | findstr mSurface"
         else:
-            command = "shell dumpsys window windows | grep -E 'mCurrentFocus'"
+            command = "shell dumpsys window windows | grep -E 'mSurface'"
         result = Adb.run_adb_command(command=command, device_id=device_id, timeout=10, fail_safe=True)
-        return bool('Window' in result.output)
+        return bool('mSurface=Surface' in result.output)
 
     @staticmethod
     def wait_until_boot(device_id, timeout=180, check_interval=3):

--- a/core/utils/device/simctl.py
+++ b/core/utils/device/simctl.py
@@ -6,6 +6,7 @@ from core.log.log import Log
 from core.utils.file_utils import File
 from core.utils.process import Process
 from core.utils.run import run
+from core.utils.xcode import Xcode
 
 
 # noinspection PyShadowingBuiltins
@@ -84,9 +85,14 @@ class Simctl(object):
             device_key = 'com.apple.CoreSimulator.SimRuntime.{0}'.format(placeholder_dash)
         sims = devices[device_key]
         for sim in sims:
-            if sim['name'] == simulator_info.name and sim['availability'] == u'(available)':
-                simulator_info.id = str(sim['udid'])
-                return simulator_info
+            if Xcode.get_version() < 11.0:
+                if sim['name'] == simulator_info.name and sim['availability'] == u'(available)':
+                    simulator_info.id = str(sim['udid'])
+                    return simulator_info
+            else:
+                if sim['name'] == simulator_info.name and sim['isAvailable']:
+                    simulator_info.id = str(sim['udid'])
+                    return simulator_info
         return False
 
     @staticmethod

--- a/run_common.py
+++ b/run_common.py
@@ -34,13 +34,13 @@ def __cleanup():
     Gradle.cache_clean()
 
 
-def __get_templates(branch='master'):
+def __get_templates(branch=Settings.Packages.TEMPLATES_BRANCH):
     """
     Clone hello-world templates and pack them as local npm packages.
     :param branch: Branch of https://github.com/NativeScript/nativescript-app-templates
     """
     local_folder = os.path.join(Settings.TEST_SUT_HOME, 'templates')
-    Git.clone(repo_url=Template.REPO, branch="master", local_folder=local_folder)
+    Git.clone(repo_url=Template.REPO, branch=branch, local_folder=local_folder)
 
     apps = [Template.HELLO_WORLD_JS, Template.HELLO_WORLD_TS, Template.HELLO_WORLD_NG, Template.MASTER_DETAIL_NG,
             Template.VUE_BLANK, Template.MASTER_DETAIL_VUE, Template.TAB_NAVIGATION_JS]

--- a/tests/templates/template_tests.py
+++ b/tests/templates/template_tests.py
@@ -1,5 +1,3 @@
-import os
-
 from parameterized import parameterized
 
 from core.base_test.tns_run_test import TnsRunTest

--- a/tests/templates/template_tests.py
+++ b/tests/templates/template_tests.py
@@ -58,7 +58,6 @@ class TemplateTests(TnsRunTest):
 
         # Create app
         app_name = template_info.name.replace('template-', '')
-        app_path = os.path.join(Settings.TEST_RUN_HOME, app_name)
         Tns.create(app_name=app_name, template='tns-' + template_name, update=False)
         if Settings.ENV != EnvironmentType.LIVE and Settings.ENV != EnvironmentType.PR:
             App.update(app_name=app_name)

--- a/tests/templates/template_tests.py
+++ b/tests/templates/template_tests.py
@@ -7,11 +7,7 @@ from core.enums.env import EnvironmentType
 from core.enums.os_type import OSType
 from core.enums.platform_type import Platform
 from core.settings import Settings
-from core.utils.device.adb import Adb
 from core.utils.device.simctl import Simctl
-from core.utils.file_utils import Folder, File
-from core.utils.gradle import Gradle
-from core.utils.npm import Npm
 from data.const import Colors
 from data.templates import Template
 from products.nativescript.app import App
@@ -58,21 +54,16 @@ class TemplateTests(TnsRunTest):
 
     @parameterized.expand(test_data)
     def test(self, template_name, template_info):
-        # Ensure template local package
-        template_folder = os.path.join(Settings.TEST_SUT_HOME, 'templates', 'packages', template_name)
-        out_file = os.path.join(Settings.TEST_SUT_HOME, template_name + '.tgz')
-        Npm.pack(folder=template_folder, output_file=out_file)
-        assert File.exists(out_file), "Failed to pack template: " + template_name
+        TnsRunTest.setUp(self)
 
         # Create app
         app_name = template_info.name.replace('template-', '')
         app_path = os.path.join(Settings.TEST_RUN_HOME, app_name)
-        Tns.create(app_name=app_name, template=template_info.local_package, update=False)
+        Tns.create(app_name=app_name, template='tns-' + template_name, update=False)
         if Settings.ENV != EnvironmentType.LIVE and Settings.ENV != EnvironmentType.PR:
             App.update(app_name=app_name)
 
         # Run Android
-        Adb.open_home(device_id=self.emu.id)
         result = Tns.run_android(app_name=app_name, device=self.emu.id)
         strings = TnsLogs.run_messages(app_name=app_name, run_type=RunType.FULL, platform=Platform.ANDROID)
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=300)
@@ -97,6 +88,4 @@ class TemplateTests(TnsRunTest):
                 self.sim.wait_for_main_color(color=Colors.WHITE, timeout=60)
 
         # Cleanup
-        Tns.kill()
-        Gradle.kill()
-        Folder.clean(app_path)
+        TnsRunTest.tearDown(self)


### PR DESCRIPTION
Features:
- Support `api29`
- Support Xcode 11 and iOS 13 (and use iOS 13 by default on Xcode 11).
- Introduce Settings.Packages.TEMPLATES_BRANCH (read it from `templates_branch` env. variable)

Fixes:
- Set correct EnvironmentType if PR detected.
- Tests for live templates now really test live templates (not from GitHub repo).