### PR TITLE
fix: failing text recognition in smoke tests

### DIFF
--- a/core/utils/image_utils.py
+++ b/core/utils/image_utils.py
@@ -127,7 +127,7 @@ class ImageUtils(object):
 
             # apply some dilation and erosion to join the gaps - change iteration to detect more or less area's
             thresh = cv2.dilate(thresh, None, iterations=5)
-            thresh = cv2.erode(thresh, None, iterations=5)
+            thresh = cv2.erode(thresh, None, iterations=3)
 
             # Find the contours
             contours, _ = cv2.findContours(thresh, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)

--- a/core/utils/image_utils.py
+++ b/core/utils/image_utils.py
@@ -126,8 +126,8 @@ class ImageUtils(object):
             thresh = cv2.adaptiveThreshold(gray, 255, 1, 1, 11, 2)
 
             # apply some dilation and erosion to join the gaps - change iteration to detect more or less area's
-            thresh = cv2.dilate(thresh, None, iterations=15)
-            thresh = cv2.erode(thresh, None, iterations=15)
+            thresh = cv2.dilate(thresh, None, iterations=5)
+            thresh = cv2.erode(thresh, None, iterations=5)
 
             # Find the contours
             contours, _ = cv2.findContours(thresh, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)


### PR DESCRIPTION
After updating some machines to xcode 10.03 text recognition from some images starts failing.
Adjusting dilation and erosion of the image fixed the problems.