### PR TITLE
feat: Add assserts for sync in preview tests

### DIFF
--- a/products/nativescript/tns_assert.py
+++ b/products/nativescript/tns_assert.py
@@ -177,3 +177,20 @@ class TnsAssert(object):
             assert 'Successfully installed plugin nativescript-unit-test-runner' in output
             assert 'Example test file created in' in output
             assert 'Run your tests using the' in output
+
+    @staticmethod
+    def file_is_synced_once(log, platform, file_name):
+        """
+        Assert file is synced once on livesync.
+        :param log: log or part of log you want to check
+        :param platform: The platform you are syncing on.
+        :param file_name: name of the file you are syncing.
+        """
+        if platform == Platform.ANDROID:
+            assert log.count('Start syncing changes for platform android') == 1, "File is synced more than once!"
+            assert log.count('hot-update.json for platform android') == 1, "File is synced more than once!"
+            assert file_name in log
+        else:
+            assert log.count('Start syncing changes for platform ios') == 1, "File is synced more than once!"
+            assert log.count('hot-update.json for platform ios') == 1, "File is synced more than once!"
+            assert file_name in log

--- a/tests/cli/preview/templates/hello_word_js_tests.py
+++ b/tests/cli/preview/templates/hello_word_js_tests.py
@@ -16,6 +16,7 @@ from data.templates import Template
 from products.nativescript.preview_helpers import Preview
 from products.nativescript.tns import Tns
 from products.nativescript.tns_logs import TnsLogs
+from products.nativescript.tns_assert import TnsAssert
 
 
 class TnsPreviewJSTests(TnsRunTest):
@@ -152,10 +153,28 @@ class PreviewJSTests(TnsPreviewJSTests):
         self.emu.wait_for_text(text=Changes.JSHelloWord.JS.new_text)
         self.sim.wait_for_text(text=Changes.JSHelloWord.JS.new_text)
 
-        # Edit XML file and verify changes are applied
+        # Check changes are not synced more than once per platform
+        # Extract the last part of the log
+        log = File.read(result.log_file)
+        log = File.extract_part_of_text(log, '[VERIFIED]')
+        # Verify files are synced once
+        TnsAssert.file_is_synced_once(log, Platform.ANDROID, 'main-view-model.js')
+        TnsAssert.file_is_synced_once(log, Platform.IOS, 'main-view-model.js')
+        # Mark that part of the log as verified before next sync
+        File.append(result.log_file, '[VERIFIED]')
+
+        # Edit XML file and verify changes are applied on both emulators
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.XML)
         self.emu.wait_for_text(text=Changes.JSHelloWord.XML.new_text)
         self.sim.wait_for_text(text=Changes.JSHelloWord.XML.new_text)
+
+        # Check changes are not synced more than once per platform
+        # Extract the last part of the log
+        log = File.read(result.log_file)
+        log = File.extract_part_of_text(log, '[VERIFIED]')
+        # Verify files are synced once
+        TnsAssert.file_is_synced_once(log, Platform.ANDROID, 'main-page.xml')
+        TnsAssert.file_is_synced_once(log, Platform.IOS, 'main-page.xml')
 
     def test_240_tns_preview_android_verify_plugin_warnings(self):
         """


### PR DESCRIPTION
Recently we had a bug that files are synced more than once per platform when you preview and livesync to both platforms.
Add method to verify in log that file is synced only once.
Add additional asserts for live sync in preview tests.