### PR TITLE
fix: debug tests on windows when modules are used from local tgz

### DIFF
--- a/core/settings/Settings.py
+++ b/core/settings/Settings.py
@@ -74,6 +74,7 @@ def resolve_package(name, variable, default=str(ENV)):
         if os.name == 'nt':
             if "tns-dist" in package:
                 package = package.replace("/tns-dist/", "\\\\telerik.com\\distributions\\DailyBuilds\\NativeScript\\")
+                package = package.replace("/", "\\")
         return package
 
 

--- a/core/settings/Settings.py
+++ b/core/settings/Settings.py
@@ -75,6 +75,9 @@ def resolve_package(name, variable, default=str(ENV)):
             if "tns-dist" in package:
                 package = package.replace("/tns-dist/", "\\\\telerik.com\\distributions\\DailyBuilds\\NativeScript\\")
                 package = package.replace("/", "\\")
+                # add next for tns-core-modules on windows for PRs, because of tns-dist dependency in the package
+                if name == 'tns-core-modules' and "PR" in package and ".tgz" in package:
+                    return name + '@next'
         return package
 
 

--- a/core/settings/Settings.py
+++ b/core/settings/Settings.py
@@ -73,7 +73,7 @@ def resolve_package(name, variable, default=str(ENV)):
     else:
         if os.name == 'nt':
             if "tns-dist" in package:
-                package = package.replace("tns-dist", "\\telerik.com\\distributions\\DailyBuilds\\NativeScript")
+                package = package.replace("/tns-dist/", "\\\\telerik.com\\distributions\\DailyBuilds\\NativeScript\\")
         return package
 
 

--- a/run_common.py
+++ b/run_common.py
@@ -80,21 +80,6 @@ def __get_runtimes():
             Npm.download(package=Settings.Packages.IOS, output_file=ios_package)
 
 
-def __fix_path_for_tns_core_modules_dependencies():
-    """
-    Fix tns-core-modules dependencies location
-    """
-    
-    share_path = "\\\\telerik.com\\distributions\\DailyBuilds\\NativeScript\\"
-    new_share_path = "\\\\telerik.com\\distributions\\DailyBuilds\\"
-    path = Settings.Packages.MODULES.replace("tns-core-modules.tgz", "")
-    require_path = path.replace(share_path, (new_share_path+"tns-dist\\"))
-    if not Folder.exists(require_path):
-        Folder.clean(require_path)
-        Folder.create(require_path)
-    Folder.copy(path, require_path, True, False)
-
-
 def __install_ns_cli():
     """
     Install NativeScript CLI locally.
@@ -141,8 +126,6 @@ def prepare(clone_templates=True, install_ng_cli=False, get_preivew_packages=Fal
     __cleanup()
     __install_ns_cli()
     __get_runtimes()
-    if os.name == 'nt' and "PR" in Settings.Packages.MODULES and ".tgz" in Settings.Packages.MODULES:
-        __fix_path_for_tns_core_modules_dependencies()
     if install_ng_cli:
         __install_ng_cli()
         __install_schematics()

--- a/run_common.py
+++ b/run_common.py
@@ -86,11 +86,12 @@ def __fix_path_for_tns_core_modules_dependencies():
     """
 
     share_path = "\\\\telerik.com\\distributions\\DailyBuilds\\NativeScript"
-    path = Settings.Packages.MODULES.replace("tns-core-modules.tgz", "")
-    require_path = path.replace(share_path, (share_path+"\\tns-dist"))
-    Folder.clean(require_path)
-    Folder.create(require_path)
-    Folder.copy(path, require_path, True, True)
+    path = Settings.Packages.MODULES.replace("tns-core-modules.tgz", "").replace("/", "\\")
+    require_path = path.replace(share_path, (share_path+"\\tns-dist")).replace("/", "\\")
+    if not Folder.exists(require_path):
+        Folder.clean(require_path)
+        Folder.create(require_path)
+    Folder.copy(path, require_path, True, False)
 
 
 def __install_ns_cli():

--- a/run_common.py
+++ b/run_common.py
@@ -85,7 +85,7 @@ def __fix_path_for_tns_core_modules_dependencies():
     Fix tns-core-modules dependencies location
     """
 
-    share_path = "\\telerik.com\\distributions\\DailyBuilds\\NativeScript"
+    share_path = "\\\\telerik.com\\distributions\\DailyBuilds\\NativeScript"
     path = Settings.Packages.MODULES.replace("tns-core-modules.tgz", "")
     require_path = path.replace(share_path, (share_path+"\\tns-dist"))
     if not Folder.exists(require_path):

--- a/run_common.py
+++ b/run_common.py
@@ -86,7 +86,7 @@ def __fix_path_for_tns_core_modules_dependencies():
     """
 
     share_path = "\\telerik.com\\distributions\\DailyBuilds\\NativeScript"
-    path = Settings.Packages.MODULES.replace("tns-core-modules.tgz", "").replace(share_path, "")
+    path = Settings.Packages.MODULES.replace("tns-core-modules.tgz", "")
     require_path = path.replace(share_path, os.path.join(share_path, "tns-dist"))
     if not Folder.exists(require_path):
         Folder.create(require_path)

--- a/run_common.py
+++ b/run_common.py
@@ -87,7 +87,7 @@ def __fix_path_for_tns_core_modules_dependencies():
 
     share_path = "\\telerik.com\\distributions\\DailyBuilds\\NativeScript"
     path = Settings.Packages.MODULES.replace("tns-core-modules.tgz", "")
-    require_path = path.replace(share_path, os.path.join(share_path, "tns-dist"))
+    require_path = path.replace(share_path, (share_path+"\\tns-dist\\"))
     if not Folder.exists(require_path):
         Folder.create(require_path)
     Folder.copy(path, require_path, True, True)

--- a/run_common.py
+++ b/run_common.py
@@ -88,7 +88,7 @@ def __fix_path_for_tns_core_modules_dependencies():
     share_path = "\\\\telerik.com\\distributions\\DailyBuilds\\NativeScript\\"
     new_share_path = "\\\\telerik.com\\distributions\\DailyBuilds\\"
     path = Settings.Packages.MODULES.replace("tns-core-modules.tgz", "")
-    require_path = path.replace(share_path, (share_path+"tns-dist\\"))
+    require_path = path.replace(share_path, (new_share_path+"tns-dist\\"))
     if not Folder.exists(require_path):
         Folder.clean(require_path)
         Folder.create(require_path)

--- a/run_common.py
+++ b/run_common.py
@@ -87,7 +87,7 @@ def __fix_path_for_tns_core_modules_dependencies():
 
     share_path = "\\telerik.com\\distributions\\DailyBuilds\\NativeScript"
     path = Settings.Packages.MODULES.replace("tns-core-modules.tgz", "")
-    require_path = path.replace(share_path, (share_path+"\\tns-dist\\"))
+    require_path = path.replace(share_path, (share_path+"\\tns-dist"))
     if not Folder.exists(require_path):
         Folder.create(require_path)
     Folder.copy(path, require_path, True, True)

--- a/run_common.py
+++ b/run_common.py
@@ -1,8 +1,10 @@
 import os
 
+from core.enums.env import EnvironmentType
 from core.enums.os_type import OSType
 from core.log.log import Log
 from core.settings import Settings
+from core.settings.Settings import get_env
 from core.utils.device.adb import Adb
 from core.utils.device.device_manager import DeviceManager
 from core.utils.file_utils import File, Folder
@@ -78,6 +80,19 @@ def __get_runtimes():
             Npm.download(package=Settings.Packages.IOS, output_file=ios_package)
 
 
+def __fix_path_for_tns_core_modules_dependencies():
+    """
+    Fix tns-core-modules dependencies location
+    """
+
+    share_path = "\\telerik.com\\distributions\\DailyBuilds\\NativeScript"
+    path = Settings.Packages.MODULES.replace("tns-core-modules.tgz", "").replace(share_path, "")
+    require_path = path.replace(share_path, os.path.join(share_path, "tns-dist"))
+    if not Folder.exists(require_path):
+        Folder.create(require_path)
+    Folder.copy(path, require_path, True, True)
+
+
 def __install_ns_cli():
     """
     Install NativeScript CLI locally.
@@ -124,6 +139,8 @@ def prepare(clone_templates=True, install_ng_cli=False, get_preivew_packages=Fal
     __cleanup()
     __install_ns_cli()
     __get_runtimes()
+    if os.name == 'nt' and "PR" in Settings.Packages.MODULES and ".tgz" in Settings.Packages.MODULES:
+        __fix_path_for_tns_core_modules_dependencies()
     if install_ng_cli:
         __install_ng_cli()
         __install_schematics()

--- a/run_common.py
+++ b/run_common.py
@@ -88,8 +88,8 @@ def __fix_path_for_tns_core_modules_dependencies():
     share_path = "\\\\telerik.com\\distributions\\DailyBuilds\\NativeScript"
     path = Settings.Packages.MODULES.replace("tns-core-modules.tgz", "")
     require_path = path.replace(share_path, (share_path+"\\tns-dist"))
-    if not Folder.exists(require_path):
-        Folder.create(require_path)
+    Folder.clean(require_path)
+    Folder.create(require_path)
     Folder.copy(path, require_path, True, True)
 
 

--- a/run_common.py
+++ b/run_common.py
@@ -85,9 +85,10 @@ def __fix_path_for_tns_core_modules_dependencies():
     Fix tns-core-modules dependencies location
     """
 
-    share_path = "\\\\telerik.com\\distributions\\DailyBuilds\\NativeScript"
-    path = Settings.Packages.MODULES.replace("tns-core-modules.tgz", "").replace("/", "\\")
-    require_path = path.replace(share_path, (share_path+"\\tns-dist")).replace("/", "\\")
+    share_path = "\\\\telerik.com\\distributions\\DailyBuilds\\NativeScript\\"
+    new_share_path = "\\\\telerik.com\\distributions\\DailyBuilds\\"
+    path = Settings.Packages.MODULES.replace("tns-core-modules.tgz", "")
+    require_path = path.replace(share_path, (share_path+"tns-dist\\"))
     if not Folder.exists(require_path):
         Folder.clean(require_path)
         Folder.create(require_path)


### PR DESCRIPTION
if on windows:
- replace `/tns-dist/` with  `\\telerik.com\distributions\DailyBuilds\NativeScript\`
- replace `/` with  `\`
- In PR for `tns-core-modules` from share replace with `tns-core-modules@next` because of `tns-dist` dependency in the package for widgets 