### PR TITLE
chore: do not clean gradle cache

### DIFF
--- a/run_common.py
+++ b/run_common.py
@@ -1,10 +1,8 @@
 import os
 
-from core.enums.env import EnvironmentType
 from core.enums.os_type import OSType
 from core.log.log import Log
 from core.settings import Settings
-from core.settings.Settings import get_env
 from core.utils.device.adb import Adb
 from core.utils.device.device_manager import DeviceManager
 from core.utils.file_utils import File, Folder
@@ -33,7 +31,6 @@ def __cleanup():
     Adb.restart()
     Tns.kill()
     Gradle.kill()
-    Gradle.cache_clean()
 
 
 def __get_templates(branch=Settings.Packages.TEMPLATES_BRANCH):

--- a/tests/cli/build/build_tests.py
+++ b/tests/cli/build/build_tests.py
@@ -27,10 +27,6 @@ class BuildTests(TnsTest):
         TnsTest.setUpClass()
         Tns.create(app_name=cls.app_name, template=Template.HELLO_WORLD_JS.local_package, update=True)
         Tns.create(cls.app_name_with_space, template=Template.HELLO_WORLD_JS.local_package, update=True)
-        # Folder.clean(os.path.join(cls.app_name, 'hooks'))
-        # Folder.clean(os.path.join(cls.app_name, 'node_modules'))
-        # Folder.clean(os.path.join(cls.app_name_with_space, 'hooks'))
-        # Folder.clean(os.path.join(cls.app_name_with_space, 'node_modules'))
         Tns.platform_add_android(cls.app_name, framework_path=Settings.Android.FRAMEWORK_PATH)
         Tns.platform_add_android(app_name='"' + cls.app_name_with_space + '"',
                                  framework_path=Settings.Android.FRAMEWORK_PATH, verify=False)


### PR DESCRIPTION
Do not clean gradle cache before tests.

Reason for this change:
- Speed up build (gradle wrapper and jars do not downloaded before `tns build/run`)
- More stable jobs (we fail because of timeout limits if we do not clean cache and network is slow)

Notes:
- It may affect build times in perf tests
- It may also affect stability of perf tests (if we do not clean cache it may be in unknown state)
- If it affect stability of perf tests we can rollback clean gradle cache only before perf tests.