### PR TITLE
fix: ios closing pop-up

### DIFF
--- a/tests/market/test_market_playgrounds.py
+++ b/tests/market/test_market_playgrounds.py
@@ -119,7 +119,8 @@ class PlaygroundMarketSamples(TnsRunTest):
 
                 Log.info('Testing iOS !!!')
                 Preview.run_url(url=link, device=self.sim)
-                if "test_0_" in self._testMethodName or "test_000_" in self._testMethodName:
+                cases = ["test_0_", "test_00_", "test_000_"]
+                if any(x in self._testMethodName for x in cases):
                     time.sleep(10)
                     PlaygroundMarketSamples.close_popup(self.sim)
                 Log.info(' Waiting iOS app to load...')


### PR DESCRIPTION
We close Preview app initial pop up in the beginning of first test but some tests has different names.