### PR TITLE
fix: temporary skip test on windows

### DIFF
--- a/tests/cli/run/templates/master_detail_ng_tests.py
+++ b/tests/cli/run/templates/master_detail_ng_tests.py
@@ -45,6 +45,8 @@ class TnsRunMasterDetailTests(TnsRunTest):
     def test_100_run_ios(self):
         sync_master_detail_ng(self.app_name, Platform.IOS, self.sim)
 
+    @unittest.skipIf(Settings.HOST_OS == OSType.WINDOWS, 'temporary skip on windows')
+    #TODO: remove skip when https://github.com/NativeScript/nativescript-dev-webpack/issues/1021 fixed
     def test_300_run_android_bundle_aot(self):
         sync_master_detail_ng(self.app_name, Platform.ANDROID, self.emu, aot=True)
 
@@ -59,6 +61,8 @@ class TnsRunMasterDetailTests(TnsRunTest):
     def test_310_run_ios_bundle_uglify(self):
         sync_master_detail_ng(self.app_name, Platform.IOS, self.sim, uglify=True)
 
+    @unittest.skipIf(Settings.HOST_OS == OSType.WINDOWS, 'temporary skip on windows')
+    #TODO: remove skip when https://github.com/NativeScript/nativescript-dev-webpack/issues/1021 fixed
     def test_320_run_android_bundle_aot_and_uglify(self):
         sync_master_detail_ng(self.app_name, Platform.ANDROID, self.emu, aot=True, uglify=True)
 

--- a/tests/cli/run/templates/master_detail_ng_tests.py
+++ b/tests/cli/run/templates/master_detail_ng_tests.py
@@ -46,7 +46,7 @@ class TnsRunMasterDetailTests(TnsRunTest):
         sync_master_detail_ng(self.app_name, Platform.IOS, self.sim)
 
     @unittest.skipIf(Settings.HOST_OS == OSType.WINDOWS, 'temporary skip on windows')
-    #TODO: remove skip when https://github.com/NativeScript/nativescript-dev-webpack/issues/1021 fixed
+    # TODO: remove skip when https://github.com/NativeScript/nativescript-dev-webpack/issues/1021 fixed
     def test_300_run_android_bundle_aot(self):
         sync_master_detail_ng(self.app_name, Platform.ANDROID, self.emu, aot=True)
 
@@ -62,7 +62,7 @@ class TnsRunMasterDetailTests(TnsRunTest):
         sync_master_detail_ng(self.app_name, Platform.IOS, self.sim, uglify=True)
 
     @unittest.skipIf(Settings.HOST_OS == OSType.WINDOWS, 'temporary skip on windows')
-    #TODO: remove skip when https://github.com/NativeScript/nativescript-dev-webpack/issues/1021 fixed
+    # TODO: remove skip when https://github.com/NativeScript/nativescript-dev-webpack/issues/1021 fixed
     def test_320_run_android_bundle_aot_and_uglify(self):
         sync_master_detail_ng(self.app_name, Platform.ANDROID, self.emu, aot=True, uglify=True)
 


### PR DESCRIPTION
Temporary skip test on win due to https://github.com/NativeScript/nativescript-dev-webpack/issues/1021 it is related to issue logged in angular-cli so we have no control when it will be fixed