### PR TITLE
fix: add timeout in test command

### DIFF
--- a/products/nativescript/tns.py
+++ b/products/nativescript/tns.py
@@ -505,7 +505,7 @@ class Tns(object):
                            'Executed 1 of 1']
                 assert 'TOTAL: 1 SUCCESS' in result.output \
                        or 'Executed 1 of 1 SUCCESS' or 'Executed 1 of 1[32m SUCCESS' in result.output
-                TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+                TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=120)
         return result
 
     @staticmethod


### PR DESCRIPTION
In tns.test method there is a wait_for_log which by default waits 1 minute. On some machines and angular projects 1 min is not always enough for the app to run on device. Fix: increase timeout to make tests more stable.