### PR TITLE
fix: update runtime tests

### DIFF
--- a/tests/runtimes/android/android_runtime_tests.py
+++ b/tests/runtimes/android/android_runtime_tests.py
@@ -591,16 +591,16 @@ JS: ==== object dump end ===="""
         assert test_result, "App not build correctly after updating tns-core modules! Logs: " + File.read(log.log_file)
         button_text = "Use ES6 language features"
 
-        test_result = Wait.until(lambda: Device.is_text_visible(self.emulator, button_text, True),
+        test_result = Wait.until(lambda: Device.is_text_visible(self.emulator, button_text),
                                  timeout=30, period=5)
         message = "Use ES6 language features Button is missing on the device! The app has crashed!"
         assert test_result, message
 
-        Device.click(self.emulator, text=button_text, case_sensitive=True)
+        Device.click(self.emulator, text=button_text, case_sensitive=False)
         test_result = Wait.until(lambda: "class com.js.NativeList" in File.read(log.log_file), timeout=25,
                                  period=5)
         assert test_result, "com.js.NativeList not found! Logs: " + File.read(log.log_file)
 
-        test_result = Wait.until(lambda: Device.is_text_visible(self.emulator, button_text, True),
+        test_result = Wait.until(lambda: Device.is_text_visible(self.emulator, button_text),
                                  timeout=30, period=5)
         assert test_result, message

--- a/tests/runtimes/ios/ios_runtime_tests.py
+++ b/tests/runtimes/ios/ios_runtime_tests.py
@@ -148,7 +148,7 @@ class IOSRuntimeTests(TnsTest):
         log = Tns.run_ios(app_name=APP_NAME, emulator=True)
 
         strings = ['CONSOLE LOG file:///app/app.js:47:0 The folder “not-existing-path” doesn’t exist.',
-                   'JS: contentsOfDirectoryAtPathError(file:///app/main-view-model.js:6:0']
+                   'JS:\ncontentsOfDirectoryAtPathError(file:///app/main-view-model.js:6:0']
 
         test_result = Wait.until(lambda: all(string in File.read(log.log_file) for string in strings), timeout=300,
                                  period=5)


### PR DESCRIPTION
- adding new line in ios log because of changes in ios-runtime - > https://github.com/NativeScript/ios-runtime/pull/1190
- change test to use case_sensitive=False because it's not needed for this test and also to make able to pass on different emulators