### PR TITLE
fix: flaky device test

### DIFF
--- a/tests/cli/device/test_run_on_device.py
+++ b/tests/cli/device/test_run_on_device.py
@@ -61,6 +61,9 @@ class TnsRunOnDevices(TnsDeviceTest):
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID, run_type=RunType.FULL)
         for device in DeviceManager.get_devices(device_type=any):
             strings.append(device.id)
+        strings.append(self.emu.id)
+        if Settings.HOST_OS is OSType.OSX:
+            strings.append(self.sim.id)
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=360)
 
         # Verify it looks properly


### PR DESCRIPTION
`test_100_run_on_all_device` often fails that image is not found on ios simulator screen. When we run on all four devices, we check in the log that app is installed on the real devices by their id, but we don't wait for the simulator id. That might cause that we wait for the image in simulator, but the app is not started there yet. Fix: add sim and emu id in the wait for log too.