### PR TITLE
fix: asserts for runtime versions

### DIFF
--- a/products/nativescript/tns_assert.py
+++ b/products/nativescript/tns_assert.py
@@ -93,10 +93,8 @@ class TnsAssert(object):
         package_json = os.path.join(app_path, 'package.json')
         json = JsonUtils.read(package_json)
         if version is not None:
-            if 'next' in version:
+            if 'next' or 'rc' in version:
                 assert json['nativescript']['tns-' + platform_string]['version'] is not None
-            if 'rc' in version:
-                assert 'rc' in json['nativescript']['tns-' + platform_string]['version']
             else:
                 assert version in json['nativescript']['tns-' + platform_string]['version']
         else:


### PR DESCRIPTION
Usually the rc versions of runtimes in npm contain 'rc' as string and we assert that in tests. Lately we often publish runtime and other packaces with versions that don't contain 'rc' string even in rc tag. That causes the tests to fail.
Fix: Remove that check because we are not sure  anymore that rc version of runtimes always contain 'rc' as string.