### PR TITLE
fix:check Androidmanifest on windows

### DIFF
--- a/products/nativescript/tns_assert.py
+++ b/products/nativescript/tns_assert.py
@@ -242,8 +242,7 @@ class TnsAssert(object):
         apk_tool = os.path.join(os.environ.get('ANDROID_HOME'), 'tools', 'bin', 'apkanalyzer')
         command = '{0} manifest print "{1}"'.format(apk_tool, path_to_apk)
         if Settings.HOST_OS == OSType.WINDOWS:
-            apk_tool=os.environ.get('APKTOOL')
-            command = '{0} d "{1} -f -o {2}"'.format(apk_tool, path_to_apk, Settings.TEST_OUT_TEMP)
+            command = 'apktool d "{1} -f -o {2}"'.format(path_to_apk, Settings.TEST_OUT_TEMP)
         result = run(command, timeout=30)
         if Settings.HOST_OS == OSType.WINDOWS:
             manifest = File.read(os.path.join(Settings.TEST_OUT_TEMP, 'AndroidManifest.xml'))

--- a/products/nativescript/tns_assert.py
+++ b/products/nativescript/tns_assert.py
@@ -242,7 +242,8 @@ class TnsAssert(object):
         apkanalyzer = os.path.join(os.environ.get('ANDROID_HOME'), 'tools', 'bin', 'apkanalyzer')
         command = '{0} manifest print "{1}"'.format(apkanalyzer, path_to_apk)
         if Settings.HOST_OS == OSType.WINDOWS:
-            apk_tool = os.path.join(os.environ.get('APKTOOL'), 'apktool')
+            print(os.environ)
+            apk_tool = os.path.join(os.environ.get('APKTOOL'), 'apktool.jar')
             command = '{0} d {1} -f -o {2}'.format(apk_tool, path_to_apk, Settings.TEST_OUT_TEMP)
         result = run(command, timeout=30)
         if Settings.HOST_OS == OSType.WINDOWS:

--- a/products/nativescript/tns_assert.py
+++ b/products/nativescript/tns_assert.py
@@ -239,8 +239,8 @@ class TnsAssert(object):
         :param path_to_apk: path to the built apk.
         :param string: string you want to assert exists in AndroidManifest.xml
         """
-        apk_tool = os.path.join(os.environ.get('ANDROID_HOME'), 'tools', 'bin', 'apkanalyzer')
-        command = '{0} manifest print "{1}"'.format(apk_tool, path_to_apk)
+        apkanalyzer = os.path.join(os.environ.get('ANDROID_HOME'), 'tools', 'bin', 'apkanalyzer')
+        command = '{0} manifest print "{1}"'.format(apkanalyzer, path_to_apk)
         if Settings.HOST_OS == OSType.WINDOWS:
             apk_tool = os.path.join(os.environ.get('APKTOOL'), 'apktool.jar')
             command = '{0} d {1} -f -o {2}'.format(apk_tool, path_to_apk, Settings.TEST_OUT_TEMP)

--- a/products/nativescript/tns_assert.py
+++ b/products/nativescript/tns_assert.py
@@ -243,7 +243,7 @@ class TnsAssert(object):
         command = '{0} manifest print "{1}"'.format(apk_tool, path_to_apk)
         if Settings.HOST_OS == OSType.WINDOWS:
             apk_tool = os.path.join(os.environ.get('APKTOOL'), 'apktool.jar')
-            command = '{0} d "{1} -f -o {2}"'.format(apk_tool, path_to_apk, Settings.TEST_OUT_TEMP)
+            command = '{0} d {1} -f -o {2}'.format(apk_tool, path_to_apk, Settings.TEST_OUT_TEMP)
         result = run(command, timeout=30)
         if Settings.HOST_OS == OSType.WINDOWS:
             manifest = File.read(os.path.join(Settings.TEST_OUT_TEMP, 'AndroidManifest.xml'))

--- a/products/nativescript/tns_assert.py
+++ b/products/nativescript/tns_assert.py
@@ -242,7 +242,8 @@ class TnsAssert(object):
         apk_tool = os.path.join(os.environ.get('ANDROID_HOME'), 'tools', 'bin', 'apkanalyzer')
         command = '{0} manifest print "{1}"'.format(apk_tool, path_to_apk)
         if Settings.HOST_OS == OSType.WINDOWS:
-            command = 'apktool d "{0} -f -o {1}"'.format(path_to_apk, Settings.TEST_OUT_TEMP)
+            apk_tool = os.path.join(os.environ.get('APKTOOL'), 'apktool.jar')
+            command = '{0} d "{1} -f -o {2}"'.format(apk_tool, path_to_apk, Settings.TEST_OUT_TEMP)
         result = run(command, timeout=30)
         if Settings.HOST_OS == OSType.WINDOWS:
             manifest = File.read(os.path.join(Settings.TEST_OUT_TEMP, 'AndroidManifest.xml'))

--- a/products/nativescript/tns_assert.py
+++ b/products/nativescript/tns_assert.py
@@ -242,7 +242,7 @@ class TnsAssert(object):
         apk_tool = os.path.join(os.environ.get('ANDROID_HOME'), 'tools', 'bin', 'apkanalyzer')
         command = '{0} manifest print "{1}"'.format(apk_tool, path_to_apk)
         if Settings.HOST_OS == OSType.WINDOWS:
-            command = 'apktool d "{1} -f -o {2}"'.format(path_to_apk, Settings.TEST_OUT_TEMP)
+            command = 'apktool d "{0} -f -o {1}"'.format(path_to_apk, Settings.TEST_OUT_TEMP)
         result = run(command, timeout=30)
         if Settings.HOST_OS == OSType.WINDOWS:
             manifest = File.read(os.path.join(Settings.TEST_OUT_TEMP, 'AndroidManifest.xml'))

--- a/products/nativescript/tns_assert.py
+++ b/products/nativescript/tns_assert.py
@@ -241,6 +241,9 @@ class TnsAssert(object):
         """
         apk_tool = os.path.join(os.environ.get('ANDROID_HOME'), 'tools', 'bin', 'apkanalyzer')
         command = '{0} manifest print "{1}"'.format(apk_tool, path_to_apk)
+        if Settings.HOST_OS == OSType.WINDOWS:
+            apk_tool=os.environ.get('APKTOOL')
+            command = '{0} d "{1} -f -o {2}"'.format(apk_tool, path_to_apk, Settings.TEST_OUT_TEMP)
         result = run(command, timeout=30)
         assert string in result.output, '{0} NOT found in AndroidManifest.xml'.format(string)
         Log.info('{0} found in AndroidManifest.xml'.format(string))

--- a/products/nativescript/tns_assert.py
+++ b/products/nativescript/tns_assert.py
@@ -242,7 +242,7 @@ class TnsAssert(object):
         apkanalyzer = os.path.join(os.environ.get('ANDROID_HOME'), 'tools', 'bin', 'apkanalyzer')
         command = '{0} manifest print "{1}"'.format(apkanalyzer, path_to_apk)
         if Settings.HOST_OS == OSType.WINDOWS:
-            apk_tool = os.path.join(os.environ.get('APKTOOL'), 'apktool.jar')
+            apk_tool = os.path.join(os.environ.get('APKTOOL'), 'apktool')
             command = '{0} d {1} -f -o {2}'.format(apk_tool, path_to_apk, Settings.TEST_OUT_TEMP)
         result = run(command, timeout=30)
         if Settings.HOST_OS == OSType.WINDOWS:

--- a/products/nativescript/tns_assert.py
+++ b/products/nativescript/tns_assert.py
@@ -242,7 +242,6 @@ class TnsAssert(object):
         apkanalyzer = os.path.join(os.environ.get('ANDROID_HOME'), 'tools', 'bin', 'apkanalyzer')
         command = '{0} manifest print "{1}"'.format(apkanalyzer, path_to_apk)
         if Settings.HOST_OS == OSType.WINDOWS:
-            print(os.environ)
             apk_tool = os.path.join(os.environ.get('APKTOOL'), 'apktool.jar')
             command = '{0} d {1} -f -o {2}'.format(apk_tool, path_to_apk, Settings.TEST_OUT_TEMP)
         result = run(command, timeout=30)

--- a/products/nativescript/tns_assert.py
+++ b/products/nativescript/tns_assert.py
@@ -245,5 +245,9 @@ class TnsAssert(object):
             apk_tool=os.environ.get('APKTOOL')
             command = '{0} d "{1} -f -o {2}"'.format(apk_tool, path_to_apk, Settings.TEST_OUT_TEMP)
         result = run(command, timeout=30)
-        assert string in result.output, '{0} NOT found in AndroidManifest.xml'.format(string)
+        if Settings.HOST_OS == OSType.WINDOWS:
+            manifest = File.read(os.path.join(Settings.TEST_OUT_TEMP, 'AndroidManifest.xml'))
+            assert string in manifest, '{0} NOT found in AndroidManifest.xml'.format(string)
+        else:
+            assert string in result.output, '{0} NOT found in AndroidManifest.xml'.format(string)
         Log.info('{0} found in AndroidManifest.xml'.format(string))


### PR DESCRIPTION
To check content in apk's Androidmanifest.xml file we use the `apkanalyzer` from the android sdk. But it turned out that there is a bug and it doesn't work on windows. 
Fix: on windows use `apktool` to extract the apk and be able to read the Androidmanifest.xml file.