### PR TITLE
chore: do not build with snapshot on catalina

### DIFF
--- a/core/utils/os_utils.py
+++ b/core/utils/os_utils.py
@@ -1,0 +1,25 @@
+import platform
+
+from core.enums.os_type import OSType
+from core.settings.Settings import HOST_OS
+from core.utils.version import Version
+
+
+class OSUtils(object):
+    @staticmethod
+    def get_version():
+        """
+        Get OS version
+        :return: Version as double.
+        """
+        result = platform.release()
+        version_string = ".".join(result.split(".", 2)[:2])
+        return Version.get(version_string)
+
+    @staticmethod
+    def is_catalina():
+        """
+        Check if current os is macOS Catalina.
+        :return: True if host OS is Catalina.
+        """
+        return HOST_OS is OSType.OSX and OSUtils.get_version() >= 19.0

--- a/tests/cli/build/android_app_bundle_tests.py
+++ b/tests/cli/build/android_app_bundle_tests.py
@@ -1,21 +1,19 @@
 import os
 import unittest
-import platform
 
-from core.enums.os_type import OSType
-from core.utils.file_utils import Folder, File
-from core.utils.device.adb import Adb
-from core.utils.os_utils import OSUtils
-from core.utils.run import run
 from core.base_test.tns_run_test import TnsRunTest
+from core.enums.os_type import OSType
 from core.settings import Settings
 from core.settings.Settings import TEST_SUT_HOME, TEST_RUN_HOME, AppName, Android
+from core.utils.device.adb import Adb
+from core.utils.file_utils import Folder, File
+from core.utils.os_utils import OSUtils
+from core.utils.run import run
 from data.templates import Template
 from products.nativescript.tns import Tns
 
 
 class AndroidAppBundleTests(TnsRunTest):
-
     app_name = AppName.DEFAULT
     app_path = os.path.join(TEST_RUN_HOME, app_name)
     target_project_dir = os.path.join(TEST_RUN_HOME, 'data', 'temp', app_name)

--- a/tests/cli/build/android_app_bundle_tests.py
+++ b/tests/cli/build/android_app_bundle_tests.py
@@ -5,6 +5,7 @@ import platform
 from core.enums.os_type import OSType
 from core.utils.file_utils import Folder, File
 from core.utils.device.adb import Adb
+from core.utils.os_utils import OSUtils
 from core.utils.run import run
 from core.base_test.tns_run_test import TnsRunTest
 from core.settings import Settings
@@ -89,7 +90,7 @@ class AndroidAppBundleTests(TnsRunTest):
         self.emu.wait_for_text(text='TAP')
 
     @unittest.skipIf(Settings.HOST_OS == OSType.WINDOWS, "Skip on Windows")
-    @unittest.skipIf(platform.platform() == 'Darwin-19.0.0-x86_64-i386-64bit', 'snapshot not working on Catalina')
+    @unittest.skipIf(OSUtils.is_catalina(), 'snapshot not working on Catalina')
     def test_205_build_android_app_bundle_env_snapshot(self):
         """Build app with android app bundle option with --bundle and optimisations for snapshot.
            Verify the output(app.aab) and use bundletool to deploy on device."""

--- a/tests/cli/build/build_tests.py
+++ b/tests/cli/build/build_tests.py
@@ -1,5 +1,4 @@
 import os
-import platform
 import unittest
 
 from core.base_test.tns_test import TnsTest
@@ -9,11 +8,12 @@ from core.settings import Settings
 from core.settings.Settings import TEST_RUN_HOME
 from core.utils.file_utils import File, Folder
 from core.utils.npm import Npm
+from core.utils.os_utils import OSUtils
 from core.utils.run import run
 from data.templates import Template
 from products.nativescript.tns import Tns
-from products.nativescript.tns_paths import TnsPaths
 from products.nativescript.tns_assert import TnsAssert
+from products.nativescript.tns_paths import TnsPaths
 
 
 class BuildTests(TnsTest):
@@ -93,7 +93,7 @@ class BuildTests(TnsTest):
         assert "Gradle build..." in result.output, "Gradle build is not called."
         assert result.output.count("Gradle build...") == 1, "More than 1 gradle build is triggered."
 
-    @unittest.skipIf(platform.platform() == 'Darwin-19.0.0-x86_64-i386-64bit', 'snapshot not working on Catalina')
+    @unittest.skipIf(OSUtils.is_catalina(), 'snapshot not working on Catalina')
     def test_002_build_android_release_uglify_snapshot_sourcemap(self):
         # https://github.com/NativeScript/nativescript-dev-webpack/issues/920
         result = Tns.build_android(self.app_name, release=True, uglify=True, snapshot=True, source_map=True)

--- a/tests/code_sharing/ng_new_tests.py
+++ b/tests/code_sharing/ng_new_tests.py
@@ -14,6 +14,7 @@ from core.enums.styling_type import StylingType
 from core.settings import Settings
 from core.utils.file_utils import Folder
 from core.utils.json_utils import JsonUtils
+from core.utils.os_utils import OSUtils
 from data.apps import Apps
 from data.const import Colors
 from products.angular.ng import NG, NS_SCHEMATICS
@@ -177,8 +178,10 @@ class NGNewTests(TnsRunTest):
 
     @staticmethod
     def build_release():
+        # Do not build with snapshot on macOS Catalina due to known issue.
+        snapshot = not OSUtils.is_catalina()
         Tns.build(app_name=NGNewTests.app_name, platform=Platform.ANDROID, release=True,
-                  bundle=True, aot=True, uglify=True, snapshot=True)
+                  bundle=True, aot=True, uglify=True, snapshot=snapshot)
         if Settings.HOST_OS is OSType.OSX:
             Tns.build(app_name=NGNewTests.app_name, platform=Platform.IOS, release=True, for_device=True,
                       bundle=True, aot=True, uglify=True)


### PR DESCRIPTION
Schematics tests:
- Do not build with snapshot on macOS Catalina

Refactor:
- Logic to detect macOS Catalina and make it working for hot fix releases of macOS Catalina