### PR TITLE
fix: ios simulator log size

### DIFF
--- a/core/utils/device/simctl.py
+++ b/core/utils/device/simctl.py
@@ -174,7 +174,7 @@ class Simctl(object):
 
     @staticmethod
     def get_log_file(device_id):
-        command = 'spawn {0} log stream --level=debug'.format(device_id)
+        command = 'spawn {0} log stream --level=default'.format(device_id)
         Process.kill_by_commandline(command)
         log_file = Simctl.run_simctl_command(command=command, wait=False).log_file
         if File.exists(log_file):

--- a/tests/cli/build/android_app_bundle_tests.py
+++ b/tests/cli/build/android_app_bundle_tests.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from core.base_test.tns_run_test import TnsRunTest
+from core.base_test.tns_run_android_test import TnsRunAndroidTest
 from core.enums.os_type import OSType
 from core.settings import Settings
 from core.settings.Settings import TEST_SUT_HOME, TEST_RUN_HOME, AppName, Android
@@ -13,7 +13,7 @@ from data.templates import Template
 from products.nativescript.tns import Tns
 
 
-class AndroidAppBundleTests(TnsRunTest):
+class AndroidAppBundleTests(TnsRunAndroidTest):
     app_name = AppName.DEFAULT
     app_path = os.path.join(TEST_RUN_HOME, app_name)
     target_project_dir = os.path.join(TEST_RUN_HOME, 'data', 'temp', app_name)
@@ -22,7 +22,7 @@ class AndroidAppBundleTests(TnsRunTest):
 
     @classmethod
     def setUpClass(cls):
-        TnsRunTest.setUpClass()
+        TnsRunAndroidTest.setUpClass()
 
         # Create app
         Tns.create(app_name=cls.app_name, template=Template.HELLO_WORLD_JS.local_package, update=True)
@@ -36,7 +36,7 @@ class AndroidAppBundleTests(TnsRunTest):
         File.download('bundletool.jar', url, TEST_SUT_HOME)
 
     def setUp(self):
-        TnsRunTest.setUp(self)
+        TnsRunAndroidTest.setUp(self)
 
         # Ensure app is in initial state
         Folder.clean(self.app_path)

--- a/tests/cli/run/tests/run_tests_api_28.py
+++ b/tests/cli/run/tests/run_tests_api_28.py
@@ -1,6 +1,6 @@
 import os
 
-from core.base_test.tns_run_test import TnsRunTest
+from core.base_test.tns_run_android_test import TnsRunAndroidTest
 from core.enums.platform_type import Platform
 from core.settings import Settings
 from core.utils.file_utils import Folder
@@ -11,14 +11,14 @@ from products.nativescript.tns_paths import TnsPaths
 Settings.Emulators.DEFAULT = Settings.Emulators.EMU_API_28
 
 
-class TnsRunJSTests(TnsRunTest):
+class TnsRunJSTests(TnsRunAndroidTest):
     app_name = Settings.AppName.DEFAULT
     source_project_dir = TnsPaths.get_app_path(app_name)
     target_project_dir = os.path.join(Settings.TEST_RUN_HOME, 'data', 'temp', app_name)
 
     @classmethod
     def setUpClass(cls):
-        TnsRunTest.setUpClass()
+        TnsRunAndroidTest.setUpClass()
 
         # Create app
         Tns.create(app_name=cls.app_name, template='tns-template-hello-world@6.0')
@@ -27,7 +27,7 @@ class TnsRunJSTests(TnsRunTest):
         Folder.copy(source=cls.source_project_dir, target=cls.target_project_dir)
 
     def setUp(self):
-        TnsRunTest.setUp(self)
+        TnsRunAndroidTest.setUp(self)
 
         # "src" folder of TestApp will be restored before each test.
         # This will ensure failures in one test do not cause common failures.
@@ -38,7 +38,7 @@ class TnsRunJSTests(TnsRunTest):
 
     @classmethod
     def tearDownClass(cls):
-        TnsRunTest.tearDownClass()
+        TnsRunAndroidTest.tearDownClass()
 
     def test_100_run_android(self):
         """


### PR DESCRIPTION
When outputting simulator log we use --level=debug. This leads to very big log files sometimes over 20MB for test set.
1. Fix: use --level=default. This will include default, error and fault log levels, which in the common case should give enough info. With that log level logs are about 2MB not 20MB.
2. Do not start iOS simulator in jobs that test only android