### PR TITLE
fix: disable pyautogui FailSafe option

### DIFF
--- a/core/utils/chrome/chrome_dev_tools.py
+++ b/core/utils/chrome/chrome_dev_tools.py
@@ -1,7 +1,5 @@
 from time import sleep
 
-import pyautogui
-pyautogui.FAILSAFE = False
 from aenum import IntEnum
 from selenium.webdriver import ActionChains
 from selenium.webdriver.common.by import By
@@ -12,6 +10,9 @@ from core.enums.platform_type import Platform
 from core.log.log import Log
 from core.settings import Settings
 from core.utils.wait import Wait
+
+import pyautogui
+pyautogui.FAILSAFE = False
 
 
 class ChromeDevToolsTabs(IntEnum):

--- a/core/utils/chrome/chrome_dev_tools.py
+++ b/core/utils/chrome/chrome_dev_tools.py
@@ -1,6 +1,7 @@
 from time import sleep
 
 import pyautogui
+pyautogui.FAILSAFE = False
 from aenum import IntEnum
 from selenium.webdriver import ActionChains
 from selenium.webdriver.common.by import By


### PR DESCRIPTION
Debug test often fail on windows with: PyAutoGUI fail-safe triggered from mouse moving to upper-left corner. To disable this fail-safe, set pyautogui.FAILSAFE to False.
This is option of PyAutoGUI we do not use for our tests. Disabling it will avoid that error and should not affect tests in any way.