### PR TITLE
fix: aab tests

### DIFF
--- a/tests/cli/build/android_app_bundle_tests.py
+++ b/tests/cli/build/android_app_bundle_tests.py
@@ -104,7 +104,7 @@ class AndroidAppBundleTests(TnsRunAndroidTest):
 
         webpack_config = os.path.join(self.app_name, 'webpack.config.js')
         File.replace(webpack_config, 'webpackConfig: config,', """webpackConfig: config,
-        \nuseLibs: true,\nandroidNdkPath: \"$ANDROID_NDK_HOME\"""")
+        \nuseLibs: true,\nandroidNdkPath: \"$ANDROID_NDK_HOME\",""")
 
         # env.snapshot is applicable only in release build
         result = Tns.build_android(self.app_path, aab=True, release=True, snapshot=True,


### PR DESCRIPTION
With the last changes, androidNdkPath: "$ANDROID_NDK_HOME is not the last argument in the snapshot section of webpack.config.json, so we need to add comma after it so the file doesn't get corrupted.