### PR TITLE
fix: check for snapshot skipped message only in 'rc'

### DIFF
--- a/data/sync/hello_world_js.py
+++ b/data/sync/hello_world_js.py
@@ -41,7 +41,9 @@ def run_hello_world_js_ts(app_name, platform, device, bundle=True, hmr=True, ugl
     result = Tns.run(app_name=app_name, platform=platform, emulator=True, wait=False, bundle=bundle, hmr=hmr,
                      release=release, uglify=uglify, aot=aot, snapshot=snapshot, sync_all_files=sync_all_files,
                      just_launch=just_launch)
-    TnsAssert.snapshot_skipped(snapshot, result, release)
+    
+    if os.environ.get('nativescript') == 'rc':
+        TnsAssert.snapshot_skipped(snapshot, result, release)
 
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.UNKNOWN, bundle=bundle,
                                    hmr=hmr, instrumented=instrumented, device=device, release=release,

--- a/data/sync/hello_world_js.py
+++ b/data/sync/hello_world_js.py
@@ -42,9 +42,6 @@ def run_hello_world_js_ts(app_name, platform, device, bundle=True, hmr=True, ugl
                      release=release, uglify=uglify, aot=aot, snapshot=snapshot, sync_all_files=sync_all_files,
                      just_launch=just_launch)
 
-    if os.environ.get('nativescript') == 'rc':
-        TnsAssert.snapshot_skipped(snapshot, result, release)
-
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.UNKNOWN, bundle=bundle,
                                    hmr=hmr, instrumented=instrumented, device=device, release=release,
                                    snapshot=snapshot)

--- a/data/sync/hello_world_js.py
+++ b/data/sync/hello_world_js.py
@@ -41,7 +41,7 @@ def run_hello_world_js_ts(app_name, platform, device, bundle=True, hmr=True, ugl
     result = Tns.run(app_name=app_name, platform=platform, emulator=True, wait=False, bundle=bundle, hmr=hmr,
                      release=release, uglify=uglify, aot=aot, snapshot=snapshot, sync_all_files=sync_all_files,
                      just_launch=just_launch)
-    
+
     if os.environ.get('nativescript') == 'rc':
         TnsAssert.snapshot_skipped(snapshot, result, release)
 

--- a/data/sync/hello_world_ng.py
+++ b/data/sync/hello_world_ng.py
@@ -29,8 +29,6 @@ def run_hello_world_ng(app_name, platform, device, bundle=True, uglify=False, ao
     # Execute tns run command
     result = Tns.run(app_name=app_name, platform=platform, emulator=emulator, bundle=bundle, aot=aot,
                      uglify=uglify, hmr=hmr, release=release, snapshot=snapshot, device=device_id)
-    if os.environ.get('nativescript') == 'rc':
-        TnsAssert.snapshot_skipped(snapshot, result, release)
 
     # Check logs
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.UNKNOWN, bundle=bundle,

--- a/data/sync/hello_world_ng.py
+++ b/data/sync/hello_world_ng.py
@@ -29,7 +29,8 @@ def run_hello_world_ng(app_name, platform, device, bundle=True, uglify=False, ao
     # Execute tns run command
     result = Tns.run(app_name=app_name, platform=platform, emulator=emulator, bundle=bundle, aot=aot,
                      uglify=uglify, hmr=hmr, release=release, snapshot=snapshot, device=device_id)
-    TnsAssert.snapshot_skipped(snapshot, result, release)
+    if os.environ.get('nativescript') == 'rc':
+        TnsAssert.snapshot_skipped(snapshot, result, release)
 
     # Check logs
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.UNKNOWN, bundle=bundle,

--- a/data/sync/hello_world_ng.py
+++ b/data/sync/hello_world_ng.py
@@ -14,7 +14,6 @@ from products.nativescript.preview_helpers import Preview
 from products.nativescript.run_type import RunType
 from products.nativescript.tns import Tns
 from products.nativescript.tns_logs import TnsLogs
-from products.nativescript.tns_assert import TnsAssert
 
 
 def run_hello_world_ng(app_name, platform, device, bundle=True, uglify=False, aot=False, hmr=True,

--- a/data/sync/master_details_ng.py
+++ b/data/sync/master_details_ng.py
@@ -20,8 +20,6 @@ def run_master_detail_ng(app_name, platform, device, bundle=True, hmr=True, ugli
                          release=False, snapshot=False):
     result = Tns.run(app_name=app_name, platform=platform, emulator=True, wait=False, bundle=bundle,
                      hmr=hmr, aot=aot, uglify=uglify, snapshot=snapshot, release=release)
-    if os.environ.get('nativescript') == 'rc':
-        TnsAssert.snapshot_skipped(snapshot, result, release)
 
     # Verify it looks properly
     device.wait_for_text(text=Changes.MasterDetailNG.TS.old_text, timeout=450, retry_delay=5)

--- a/data/sync/master_details_ng.py
+++ b/data/sync/master_details_ng.py
@@ -20,7 +20,8 @@ def run_master_detail_ng(app_name, platform, device, bundle=True, hmr=True, ugli
                          release=False, snapshot=False):
     result = Tns.run(app_name=app_name, platform=platform, emulator=True, wait=False, bundle=bundle,
                      hmr=hmr, aot=aot, uglify=uglify, snapshot=snapshot, release=release)
-    TnsAssert.snapshot_skipped(snapshot, result, release)
+    if os.environ.get('nativescript') == 'rc':
+        TnsAssert.snapshot_skipped(snapshot, result, release)
 
     # Verify it looks properly
     device.wait_for_text(text=Changes.MasterDetailNG.TS.old_text, timeout=450, retry_delay=5)

--- a/data/sync/master_details_ng.py
+++ b/data/sync/master_details_ng.py
@@ -13,7 +13,6 @@ from core.utils.wait import Wait
 from data.changes import Changes, Sync
 from data.const import Colors
 from products.nativescript.tns import Tns
-from products.nativescript.tns_assert import TnsAssert
 
 
 def run_master_detail_ng(app_name, platform, device, bundle=True, hmr=True, uglify=False, aot=False,


### PR DESCRIPTION
Snapshots are not skipped anymore on windows, we can build with docker now. 
Remove the snapshot skipped check from tests