### PR TITLE
fix: increase timeout

### DIFF
--- a/data/sync/hello_world_js.py
+++ b/data/sync/hello_world_js.py
@@ -36,7 +36,7 @@ def sync_hello_world_ts(app_name, platform, device, bundle=True, hmr=True, uglif
 
 def run_hello_world_js_ts(app_name, platform, device, bundle=True, hmr=True, uglify=False, release=False,
                           aot=False, snapshot=False, instrumented=False, sync_all_files=False, just_launch=False,
-                          default_andr_sdk='29'):
+                          default_andr_sdk='29', timeout=240):
     # Execute `tns run` and wait until logs are OK
     result = Tns.run(app_name=app_name, platform=platform, emulator=True, wait=False, bundle=bundle, hmr=hmr,
                      release=release, uglify=uglify, aot=aot, snapshot=snapshot, sync_all_files=sync_all_files,
@@ -45,7 +45,7 @@ def run_hello_world_js_ts(app_name, platform, device, bundle=True, hmr=True, ugl
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.UNKNOWN, bundle=bundle,
                                    hmr=hmr, instrumented=instrumented, device=device, release=release,
                                    snapshot=snapshot)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=240)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=timeout)
 
     # Verify it looks properly
     device.wait_for_text(text=Changes.JSHelloWord.JS.old_text)

--- a/products/nativescript/tns_logs.py
+++ b/products/nativescript/tns_logs.py
@@ -127,7 +127,7 @@ class TnsLogs(object):
                                 'the production mode.')
 
         # Add message for snapshot
-        if snapshot and release and Settings.HOST_OS != OSType.WINDOWS:
+        if snapshot and release:
             logs.append('Successfully generated snapshots')
             logs.append('Snapshot enabled')
 

--- a/tests/cli/run/templates/hello_world_js_tests.py
+++ b/tests/cli/run/templates/hello_world_js_tests.py
@@ -59,4 +59,4 @@ class TnsRunJSTests(TnsRunTest):
 
     def test_320_run_android_release_snapshot_uglify(self):
         run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, uglify=True, release=True,
-                              snapshot=True, timeout=300)
+                              snapshot=True)

--- a/tests/cli/run/templates/hello_world_js_tests.py
+++ b/tests/cli/run/templates/hello_world_js_tests.py
@@ -58,4 +58,5 @@ class TnsRunJSTests(TnsRunTest):
         sync_hello_world_js(self.app_name, Platform.IOS, self.sim, uglify=True)
 
     def test_320_run_android_release_snapshot_uglify(self):
-        run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, uglify=True, release=True, snapshot=True)
+        run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, uglify=True, release=True,
+                              snapshot=True, timeout=300)

--- a/tests/cli/run/templates/hello_world_ts_tests.py
+++ b/tests/cli/run/templates/hello_world_ts_tests.py
@@ -66,4 +66,5 @@ class TnsRunTSTests(TnsRunTest):
         sync_hello_world_ts(self.app_name, Platform.IOS, self.sim, uglify=True)
 
     def test_315_run_android_release_snapshot_uglify(self):
-        run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, uglify=True, snapshot=True, release=True)
+        run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, uglify=True, snapshot=True,
+                              release=True, timeout=300)

--- a/tests/cli/run/templates/hello_world_ts_tests.py
+++ b/tests/cli/run/templates/hello_world_ts_tests.py
@@ -67,4 +67,4 @@ class TnsRunTSTests(TnsRunTest):
 
     def test_315_run_android_release_snapshot_uglify(self):
         run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, uglify=True, snapshot=True,
-                              release=True, timeout=300)
+                              release=True)

--- a/tests/cli/run/tests/run_tests_api_28.py
+++ b/tests/cli/run/tests/run_tests_api_28.py
@@ -53,4 +53,4 @@ class TnsRunJSTests(TnsRunAndroidTest):
         """
         # Run app and verify on emulator
         run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, default_andr_sdk='28',
-                              release=True, snapshot=True)
+                              release=True, snapshot=True, timeout=300)

--- a/tests/cli/run/tests/run_tests_api_28.py
+++ b/tests/cli/run/tests/run_tests_api_28.py
@@ -53,4 +53,4 @@ class TnsRunJSTests(TnsRunAndroidTest):
         """
         # Run app and verify on emulator
         run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, default_andr_sdk='28',
-                              release=True, snapshot=True, timeout=300)
+                              release=True, snapshot=True)


### PR DESCRIPTION
On win we build snapshot with docker, but apparently this is not very fast and the test timeouts before the build is finished.
Fix: add timeout option and increase it for builds on win with snapshot