### PR TITLE
feat: add aab tests

### DIFF
--- a/products/nativescript/tns.py
+++ b/products/nativescript/tns.py
@@ -25,7 +25,7 @@ class Tns(object):
     def exec_command(command, cwd=Settings.TEST_RUN_HOME, platform=Platform.NONE, emulator=False, path=None,
                      device=None, release=False, for_device=False, provision=None, bundle=True,
                      hmr=True, aot=False, uglify=False, source_map=False, snapshot=False, log_trace=False,
-                     just_launch=False, sync_all_files=False, clean=False, aab=False,
+                     just_launch=False, sync_all_files=False, clean=False, aab=False, compileSnapshot=False,
                      options=None, wait=True, timeout=600):
         """
         Execute tns command.
@@ -85,6 +85,8 @@ class Tns(object):
             cmd += ' --env.uglify'
         if snapshot:
             cmd += ' --env.snapshot'
+        if compileSnapshot:
+            cmd += ' --env.compileSnapshot'
         if source_map:
             cmd += ' --env.sourceMap'
         if just_launch:
@@ -321,11 +323,11 @@ class Tns(object):
     @staticmethod
     def build(app_name, platform, release=False, provision=Settings.IOS.PROVISIONING, for_device=False, bundle=True,
               aot=False, source_map=False, uglify=False, snapshot=False, log_trace=False, verify=True, app_data=None,
-              aab=False):
+              aab=False, compileSnapshot=False):
         result = Tns.exec_command(command='build', path=app_name, platform=platform, release=release,
                                   provision=provision, for_device=for_device, bundle=bundle, aot=aot,
                                   source_map=source_map, uglify=uglify, snapshot=snapshot, wait=True,
-                                  log_trace=log_trace, aab=aab)
+                                  log_trace=log_trace, aab=aab, compileSnapshot=compileSnapshot)
         if verify:
             # Verify output
             assert result.exit_code == 0, 'Build failed with non zero exit code.'
@@ -349,10 +351,10 @@ class Tns(object):
 
     @staticmethod
     def build_android(app_name, release=False, bundle=True, aot=False, source_map=False, uglify=False, snapshot=False,
-                      log_trace=False, verify=True, app_data=None, aab=False):
+                      log_trace=False, verify=True, app_data=None, aab=False, compileSnapshot=False):
         return Tns.build(app_name=app_name, platform=Platform.ANDROID, release=release, bundle=bundle, aot=aot,
                          source_map=source_map, uglify=uglify, snapshot=snapshot, log_trace=log_trace, verify=verify,
-                         app_data=app_data, aab=aab)
+                         app_data=app_data, aab=aab, compileSnapshot=compileSnapshot)
 
     @staticmethod
     def build_ios(app_name, release=False, provision=Settings.IOS.PROVISIONING, for_device=False,
@@ -376,12 +378,13 @@ class Tns(object):
     @staticmethod
     def run(app_name, platform, emulator=False, device=None, release=False, provision=Settings.IOS.PROVISIONING,
             for_device=False, bundle=True, hmr=True, aot=False, uglify=False, source_map=False, snapshot=False,
-            wait=False, log_trace=False, just_launch=False, sync_all_files=False, clean=False, verify=True):
+            wait=False, log_trace=False, just_launch=False, sync_all_files=False, clean=False, verify=True,
+            compileSnapshot=False):
         result = Tns.exec_command(command='run', path=app_name, platform=platform, emulator=emulator, device=device,
                                   release=release, provision=provision, for_device=for_device, bundle=bundle,
                                   hmr=hmr, aot=aot, uglify=uglify, source_map=source_map, snapshot=snapshot,
                                   clean=clean, wait=wait, log_trace=log_trace, just_launch=just_launch,
-                                  sync_all_files=sync_all_files)
+                                  sync_all_files=sync_all_files, compileSnapshot=compileSnapshot)
         if verify:
             if wait:
                 assert result.exit_code == 0, 'tns run failed with non zero exit code.'
@@ -393,10 +396,11 @@ class Tns(object):
     @staticmethod
     def run_android(app_name, emulator=False, device=None, release=False, bundle=True, hmr=True, aot=False,
                     uglify=False, source_map=False, snapshot=False, wait=False, log_trace=False, just_launch=False,
-                    verify=True, clean=False):
+                    verify=True, clean=False, compileSnapshot=False):
         return Tns.run(app_name=app_name, platform=Platform.ANDROID, emulator=emulator, device=device, release=release,
                        bundle=bundle, hmr=hmr, aot=aot, uglify=uglify, source_map=source_map, snapshot=snapshot,
-                       wait=wait, log_trace=log_trace, just_launch=just_launch, verify=verify, clean=clean)
+                       wait=wait, log_trace=log_trace, just_launch=just_launch, verify=verify, clean=clean,
+                       compileSnapshot=compileSnapshot)
 
     @staticmethod
     def run_ios(app_name, emulator=False, device=None, release=False, provision=Settings.IOS.PROVISIONING,

--- a/products/nativescript/tns.py
+++ b/products/nativescript/tns.py
@@ -86,7 +86,7 @@ class Tns(object):
         if snapshot:
             cmd += ' --env.snapshot'
         if compile_snapshot:
-            cmd += ' --env.compile_snapshot'
+            cmd += ' --env.compileSnapshot'
         if source_map:
             cmd += ' --env.sourceMap'
         if just_launch:

--- a/products/nativescript/tns.py
+++ b/products/nativescript/tns.py
@@ -379,7 +379,7 @@ class Tns(object):
     def run(app_name, platform, emulator=False, device=None, release=False, provision=Settings.IOS.PROVISIONING,
             for_device=False, bundle=True, hmr=True, aot=False, uglify=False, source_map=False, snapshot=False,
             wait=False, log_trace=False, just_launch=False, sync_all_files=False, clean=False, verify=True,
-            compileSnapshot=False):
+            compileSnapshot=False, aab=False):
         result = Tns.exec_command(command='run', path=app_name, platform=platform, emulator=emulator, device=device,
                                   release=release, provision=provision, for_device=for_device, bundle=bundle,
                                   hmr=hmr, aot=aot, uglify=uglify, source_map=source_map, snapshot=snapshot,
@@ -396,11 +396,11 @@ class Tns(object):
     @staticmethod
     def run_android(app_name, emulator=False, device=None, release=False, bundle=True, hmr=True, aot=False,
                     uglify=False, source_map=False, snapshot=False, wait=False, log_trace=False, just_launch=False,
-                    verify=True, clean=False, compileSnapshot=False):
+                    verify=True, clean=False, compileSnapshot=False, aab=False):
         return Tns.run(app_name=app_name, platform=Platform.ANDROID, emulator=emulator, device=device, release=release,
                        bundle=bundle, hmr=hmr, aot=aot, uglify=uglify, source_map=source_map, snapshot=snapshot,
                        wait=wait, log_trace=log_trace, just_launch=just_launch, verify=verify, clean=clean,
-                       compileSnapshot=compileSnapshot)
+                       compileSnapshot=compileSnapshot, aab=aab)
 
     @staticmethod
     def run_ios(app_name, emulator=False, device=None, release=False, provision=Settings.IOS.PROVISIONING,

--- a/products/nativescript/tns.py
+++ b/products/nativescript/tns.py
@@ -25,7 +25,7 @@ class Tns(object):
     def exec_command(command, cwd=Settings.TEST_RUN_HOME, platform=Platform.NONE, emulator=False, path=None,
                      device=None, release=False, for_device=False, provision=None, bundle=True,
                      hmr=True, aot=False, uglify=False, source_map=False, snapshot=False, log_trace=False,
-                     just_launch=False, sync_all_files=False, clean=False, aab=False, compileSnapshot=False,
+                     just_launch=False, sync_all_files=False, clean=False, aab=False, compile_snapshot=False,
                      options=None, wait=True, timeout=600):
         """
         Execute tns command.
@@ -85,8 +85,8 @@ class Tns(object):
             cmd += ' --env.uglify'
         if snapshot:
             cmd += ' --env.snapshot'
-        if compileSnapshot:
-            cmd += ' --env.compileSnapshot'
+        if compile_snapshot:
+            cmd += ' --env.compile_snapshot'
         if source_map:
             cmd += ' --env.sourceMap'
         if just_launch:
@@ -323,11 +323,11 @@ class Tns(object):
     @staticmethod
     def build(app_name, platform, release=False, provision=Settings.IOS.PROVISIONING, for_device=False, bundle=True,
               aot=False, source_map=False, uglify=False, snapshot=False, log_trace=False, verify=True, app_data=None,
-              aab=False, compileSnapshot=False):
+              aab=False, compile_snapshot=False):
         result = Tns.exec_command(command='build', path=app_name, platform=platform, release=release,
                                   provision=provision, for_device=for_device, bundle=bundle, aot=aot,
                                   source_map=source_map, uglify=uglify, snapshot=snapshot, wait=True,
-                                  log_trace=log_trace, aab=aab, compileSnapshot=compileSnapshot)
+                                  log_trace=log_trace, aab=aab, compile_snapshot=compile_snapshot)
         if verify:
             # Verify output
             assert result.exit_code == 0, 'Build failed with non zero exit code.'
@@ -351,10 +351,10 @@ class Tns(object):
 
     @staticmethod
     def build_android(app_name, release=False, bundle=True, aot=False, source_map=False, uglify=False, snapshot=False,
-                      log_trace=False, verify=True, app_data=None, aab=False, compileSnapshot=False):
+                      log_trace=False, verify=True, app_data=None, aab=False, compile_snapshot=False):
         return Tns.build(app_name=app_name, platform=Platform.ANDROID, release=release, bundle=bundle, aot=aot,
                          source_map=source_map, uglify=uglify, snapshot=snapshot, log_trace=log_trace, verify=verify,
-                         app_data=app_data, aab=aab, compileSnapshot=compileSnapshot)
+                         app_data=app_data, aab=aab, compile_snapshot=compile_snapshot)
 
     @staticmethod
     def build_ios(app_name, release=False, provision=Settings.IOS.PROVISIONING, for_device=False,
@@ -379,12 +379,12 @@ class Tns(object):
     def run(app_name, platform, emulator=False, device=None, release=False, provision=Settings.IOS.PROVISIONING,
             for_device=False, bundle=True, hmr=True, aot=False, uglify=False, source_map=False, snapshot=False,
             wait=False, log_trace=False, just_launch=False, sync_all_files=False, clean=False, verify=True,
-            compileSnapshot=False, aab=False):
+            compile_snapshot=False, aab=False):
         result = Tns.exec_command(command='run', path=app_name, platform=platform, emulator=emulator, device=device,
                                   release=release, provision=provision, for_device=for_device, bundle=bundle,
                                   hmr=hmr, aot=aot, uglify=uglify, source_map=source_map, snapshot=snapshot,
                                   clean=clean, wait=wait, log_trace=log_trace, just_launch=just_launch,
-                                  sync_all_files=sync_all_files, compileSnapshot=compileSnapshot)
+                                  sync_all_files=sync_all_files, compile_snapshot=compile_snapshot, aab=aab)
         if verify:
             if wait:
                 assert result.exit_code == 0, 'tns run failed with non zero exit code.'
@@ -396,11 +396,11 @@ class Tns(object):
     @staticmethod
     def run_android(app_name, emulator=False, device=None, release=False, bundle=True, hmr=True, aot=False,
                     uglify=False, source_map=False, snapshot=False, wait=False, log_trace=False, just_launch=False,
-                    verify=True, clean=False, compileSnapshot=False, aab=False):
+                    verify=True, clean=False, compile_snapshot=False, aab=False):
         return Tns.run(app_name=app_name, platform=Platform.ANDROID, emulator=emulator, device=device, release=release,
                        bundle=bundle, hmr=hmr, aot=aot, uglify=uglify, source_map=source_map, snapshot=snapshot,
                        wait=wait, log_trace=log_trace, just_launch=just_launch, verify=verify, clean=clean,
-                       compileSnapshot=compileSnapshot, aab=aab)
+                       compile_snapshot=compile_snapshot, aab=aab)
 
     @staticmethod
     def run_ios(app_name, emulator=False, device=None, release=False, provision=Settings.IOS.PROVISIONING,

--- a/tests/cli/build/android_app_bundle_tests.py
+++ b/tests/cli/build/android_app_bundle_tests.py
@@ -77,7 +77,7 @@ class AndroidAppBundleTests(TnsRunAndroidTest):
 
         # env.snapshot is applicable only in release build
         result = Tns.run_android(self.app_path, aab=True, release=True, snapshot=True,
-                                 uglify=True, verify=False, compileSnapshot=True)
+                                 uglify=True, verify=False, compile_snapshot=True)
         strings = ['Successfully generated snapshots',
                    'The build result is located at: {0}'.format(path_to_aab)]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)

--- a/tests/cli/build/android_app_bundle_tests.py
+++ b/tests/cli/build/android_app_bundle_tests.py
@@ -92,7 +92,7 @@ class AndroidAppBundleTests(TnsRunAndroidTest):
         File.unzip(os.path.join(self.app_name, 'apks', 'standalones', 'standalone-arm64_v8a_hdpi.apk'),
                    os.path.join(self.app_name, 'standalone-arm64'))
         assert File.exists(os.path.join(self.app_name, 'standalone-arm64', 'lib', 'arm64-v8a', 'libNativeScript.so'))
-        assert  not File.exists(os.path.join(self.app_name, 'standalone-arm64', 'assets', 'snapshots', 'x86_64',
+        assert not File.exists(os.path.join(self.app_name, 'standalone-arm64', 'assets', 'snapshots', 'x86_64',
                                              'snapshot.blob'))
 
     def test_200_build_android_app_bundle(self):

--- a/tests/cli/build/android_app_bundle_tests.py
+++ b/tests/cli/build/android_app_bundle_tests.py
@@ -80,7 +80,7 @@ class AndroidAppBundleTests(TnsRunAndroidTest):
                                    uglify=True, verify=False, compileSnapshot=True)
         strings = ['Successfully generated snapshots',
                    'The build result is located at: {0}'.format(path_to_aab)]
-        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
        
         # Verify app can be deployed on emulator via nativescript
         # Verify app looks correct inside emulator

--- a/tests/cli/build/android_app_bundle_tests.py
+++ b/tests/cli/build/android_app_bundle_tests.py
@@ -8,6 +8,7 @@ from core.utils.run import run
 from core.utils.docker import Docker
 from data.templates import Template
 from products.nativescript.tns import Tns
+from products.nativescript.tns_logs import TnsLogs
 
 
 class AndroidAppBundleTests(TnsRunAndroidTest):

--- a/tests/cli/build/android_app_bundle_tests.py
+++ b/tests/cli/build/android_app_bundle_tests.py
@@ -73,15 +73,15 @@ class AndroidAppBundleTests(TnsRunAndroidTest):
         path_to_aab = os.path.join(self.app_name, "platforms", "android", "app", "build",
                                    "outputs", "bundle", "release", "app-release.aab")
         path_to_apks = os.path.join(self.app_name, "platforms", "android", "app", "build",
-                                   "outputs", "bundle", "release", "app-release.apks")
+                                    "outputs", "bundle", "release", "app-release.apks")
 
         # env.snapshot is applicable only in release build
         result = Tns.run_android(self.app_path, aab=True, release=True, snapshot=True,
-                                   uglify=True, verify=False, compileSnapshot=True)
+                                 uglify=True, verify=False, compileSnapshot=True)
         strings = ['Successfully generated snapshots',
                    'The build result is located at: {0}'.format(path_to_aab)]
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
-       
+
         # Verify app can be deployed on emulator via nativescript
         # Verify app looks correct inside emulator
         self.emu.wait_for_text(text='TAP')
@@ -93,7 +93,7 @@ class AndroidAppBundleTests(TnsRunAndroidTest):
         assert File.exists(os.path.join(self.app_name, 'standalone-arm64', 'lib', 'arm64-v8a', 'libNativeScript.so'))
         assert  not File.exists(os.path.join(self.app_name, 'standalone-arm64', 'assets', 'snapshots', 'x86_64',
                                              'snapshot.blob'))
-    
+
     def test_200_build_android_app_bundle(self):
         """Build app with android app bundle option. Verify the output(app.aab) and use bundletool
            to deploy on device."""

--- a/tests/cli/build/android_app_bundle_tests.py
+++ b/tests/cli/build/android_app_bundle_tests.py
@@ -65,9 +65,37 @@ class AndroidAppBundleTests(TnsRunAndroidTest):
         assert "Error" not in result.output, "deploy of app failed"
         assert "The APKs have been extracted in the directory:" in result.output, "deploy of app failed"
 
+    def test_100_run_android_app_bundle_compile_snapshot(self):
+        """Run app on android with --aab option with optimisations for snapshot.
+           Verify the output(app.aab)."""
+
+        path_to_aab = os.path.join(self.app_name, "platforms", "android", "app", "build",
+                                   "outputs", "bundle", "release", "app-release.aab")
+        path_to_apks = os.path.join(self.app_name, "platforms", "android", "app", "build",
+                                   "outputs", "bundle", "release", "app-release.apks")
+
+        # env.snapshot is applicable only in release build
+        result = Tns.run_android(self.app_path, aab=True, release=True, snapshot=True,
+                                   uglify=True, verify=False, compileSnapshot=True)
+        strings = ['Successfully generated snapshots',
+                   'The build result is located at: {0}'.format(path_to_aab)]
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+       
+        # Verify app can be deployed on emulator via nativescript
+        # Verify app looks correct inside emulator
+        self.emu.wait_for_text(text='TAP')
+
+        # Verify that the correct .so file is included in the package
+        File.unzip(path_to_apks, os.path.join(self.app_name, 'apks'))
+        File.unzip(os.path.join(self.app_name, 'apks', 'standalones', 'standalone-arm64_v8a_hdpi.apk'),
+                   os.path.join(self.app_name, 'standalone-arm64'))
+        assert File.exists(os.path.join(self.app_name, 'standalone-arm64', 'lib', 'arm64-v8a', 'libNativeScript.so'))
+        assert  not File.exists(os.path.join(self.app_name, 'standalone-arm64', 'assets', 'snapshots', 'x86_64',
+                                             'snapshot.blob'))
+    
     def test_200_build_android_app_bundle(self):
         """Build app with android app bundle option. Verify the output(app.aab) and use bundletool
-           to deploy on device"""
+           to deploy on device."""
         path_to_aab = os.path.join(self.app_name, "platforms", "android", "app", "build", "outputs",
                                    "bundle", "debug", "app-debug.aab")
 

--- a/tests/cli/build/android_app_bundle_tests.py
+++ b/tests/cli/build/android_app_bundle_tests.py
@@ -9,6 +9,7 @@ from core.utils.docker import Docker
 from data.templates import Template
 from products.nativescript.tns import Tns
 from products.nativescript.tns_logs import TnsLogs
+from products.nativescript.tns_paths import TnsPaths
 
 
 class AndroidAppBundleTests(TnsRunAndroidTest):
@@ -70,9 +71,9 @@ class AndroidAppBundleTests(TnsRunAndroidTest):
         """Run app on android with --aab option with optimisations for snapshot.
            Verify the output(app.aab)."""
 
-        path_to_aab = os.path.join(self.app_name, "platforms", "android", "app", "build",
+        path_to_aab = os.path.join(TnsPaths.get_app_path(self.app_name), "platforms", "android", "app", "build",
                                    "outputs", "bundle", "release", "app-release.aab")
-        path_to_apks = os.path.join(self.app_name, "platforms", "android", "app", "build",
+        path_to_apks = os.path.join(TnsPaths.get_app_path(self.app_name), "platforms", "android", "app", "build",
                                     "outputs", "bundle", "release", "app-release.apks")
 
         # env.snapshot is applicable only in release build

--- a/tests/cli/build/android_app_bundle_tests.py
+++ b/tests/cli/build/android_app_bundle_tests.py
@@ -93,7 +93,7 @@ class AndroidAppBundleTests(TnsRunAndroidTest):
                    os.path.join(self.app_name, 'standalone-arm64'))
         assert File.exists(os.path.join(self.app_name, 'standalone-arm64', 'lib', 'arm64-v8a', 'libNativeScript.so'))
         assert not File.exists(os.path.join(self.app_name, 'standalone-arm64', 'assets', 'snapshots', 'x86_64',
-                                             'snapshot.blob'))
+                                            'snapshot.blob'))
 
     def test_200_build_android_app_bundle(self):
         """Build app with android app bundle option. Verify the output(app.aab) and use bundletool


### PR DESCRIPTION
With the new workflow build with --aab with snapshot will not require any additional setup. Also --abb will be available for run, debug, test commands also
Keep current tests to test compatibility with the old setup, and add new test to test `tns run --aab --compilesnapshot`