### PR TITLE
chore: cleanup app if test passes

### DIFF
--- a/tests/templates/template_tests.py
+++ b/tests/templates/template_tests.py
@@ -1,3 +1,5 @@
+import os
+
 from parameterized import parameterized
 
 from core.base_test.tns_run_test import TnsRunTest
@@ -6,6 +8,7 @@ from core.enums.os_type import OSType
 from core.enums.platform_type import Platform
 from core.settings import Settings
 from core.utils.device.simctl import Simctl
+from core.utils.file_utils import Folder
 from data.const import Colors
 from data.templates import Template
 from products.nativescript.app import App
@@ -80,4 +83,5 @@ class TemplateTests(TnsRunTest):
                 self.sim.wait_for_main_color(color=Colors.WHITE, timeout=60)
 
         # Cleanup
+        Folder.clean(os.path.join(Settings.TEST_RUN_HOME, app_name))
         TnsRunTest.tearDown(self)


### PR DESCRIPTION
http://nsbuild01:8080/build/job/live-templates/ uses a lot of disk space on slaves beause we create 20+ apps (each is 500+ MB when build for both platforms).

Fix:
- Delete app as last step
- If something fails it will not reach the line to delete, so app will be in the workspace to investigate issues.