### PR TITLE
feat: add more asserts for hmr

### DIFF
--- a/data/sync/blank_vue.py
+++ b/data/sync/blank_vue.py
@@ -49,6 +49,8 @@ def __workflow(preview, app_name, platform, device, bundle=True, hmr=True):
     # Verify that application is not restarted on file changes when hmr=true
     if hmr:
         not_existing_string_list = ['Restarting application']
+    else:
+        not_existing_string_list=None
     
     # Edit script in .vue file
     Sync.replace(app_name=app_name, change_set=Changes.BlankVue.VUE_SCRIPT)

--- a/data/sync/blank_vue.py
+++ b/data/sync/blank_vue.py
@@ -46,6 +46,10 @@ def __workflow(preview, app_name, platform, device, bundle=True, hmr=True):
     initial_state = os.path.join(Settings.TEST_OUT_IMAGES, device.name, 'initial_state.png')
     device.get_screen(path=initial_state)
 
+    # Verify that application is not restarted on file changes when hmr=true
+    if hmr:
+        not_existing_string_list = ['Restarting application']
+    
     # Edit script in .vue file
     Sync.replace(app_name=app_name, change_set=Changes.BlankVue.VUE_SCRIPT)
     if preview:
@@ -53,7 +57,8 @@ def __workflow(preview, app_name, platform, device, bundle=True, hmr=True):
     else:
         strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL,
                                        bundle=bundle, hmr=hmr, app_type=AppType.VUE, file_name='Home.vue')
-        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
+                             not_existing_string_list=not_existing_string_list)
     device.wait_for_text(text=Changes.BlankVue.VUE_SCRIPT.new_text)
 
     # Edit template in .vue file
@@ -63,7 +68,8 @@ def __workflow(preview, app_name, platform, device, bundle=True, hmr=True):
     else:
         strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL,
                                        bundle=bundle, hmr=hmr, app_type=AppType.VUE, file_name='Home.vue')
-        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
+                             not_existing_string_list=not_existing_string_list)
     device.wait_for_text(text=Changes.BlankVue.VUE_TEMPLATE.new_text)
 
     # Edit styling in .vue file
@@ -73,7 +79,8 @@ def __workflow(preview, app_name, platform, device, bundle=True, hmr=True):
     else:
         strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL,
                                        bundle=bundle, hmr=hmr, app_type=AppType.VUE, file_name='Home.vue')
-        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, 
+                             not_existing_string_list=not_existing_string_list)
     style_applied = Wait.until(lambda: device.get_pixels_by_color(Colors.RED) > 100)
     assert style_applied, 'Failed to sync changes in style.'
 
@@ -84,7 +91,8 @@ def __workflow(preview, app_name, platform, device, bundle=True, hmr=True):
     else:
         strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL,
                                        bundle=bundle, hmr=hmr, app_type=AppType.VUE, file_name='Home.vue')
-        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
+                             not_existing_string_list=not_existing_string_list)
     device.wait_for_text(text=Changes.BlankVue.VUE_SCRIPT.old_text)
 
     # Revert template in .vue file
@@ -94,7 +102,8 @@ def __workflow(preview, app_name, platform, device, bundle=True, hmr=True):
     else:
         strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL,
                                        bundle=bundle, hmr=hmr, app_type=AppType.VUE, file_name='Home.vue')
-        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
+                             not_existing_string_list=not_existing_string_list)
     device.wait_for_text(text=Changes.BlankVue.VUE_TEMPLATE.old_text)
 
     # Revert styling in .vue file
@@ -105,7 +114,8 @@ def __workflow(preview, app_name, platform, device, bundle=True, hmr=True):
         strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL,
                                        bundle=bundle,
                                        hmr=hmr, app_type=AppType.VUE, file_name='Home.vue')
-        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
+                             not_existing_string_list=not_existing_string_list)
 
     if hmr:
         Log.info('Skip next steps because of https://github.com/nativescript-vue/nativescript-vue/issues/425')

--- a/data/sync/blank_vue.py
+++ b/data/sync/blank_vue.py
@@ -50,8 +50,8 @@ def __workflow(preview, app_name, platform, device, bundle=True, hmr=True):
     if hmr:
         not_existing_string_list = ['Restarting application']
     else:
-        not_existing_string_list=None
-    
+        not_existing_string_list = None
+
     # Edit script in .vue file
     Sync.replace(app_name=app_name, change_set=Changes.BlankVue.VUE_SCRIPT)
     if preview:
@@ -81,7 +81,7 @@ def __workflow(preview, app_name, platform, device, bundle=True, hmr=True):
     else:
         strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL,
                                        bundle=bundle, hmr=hmr, app_type=AppType.VUE, file_name='Home.vue')
-        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, 
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
                              not_existing_string_list=not_existing_string_list)
     style_applied = Wait.until(lambda: device.get_pixels_by_color(Colors.RED) > 100)
     assert style_applied, 'Failed to sync changes in style.'

--- a/data/sync/hello_world_js.py
+++ b/data/sync/hello_world_js.py
@@ -86,7 +86,7 @@ def __sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=True, 
     if hmr:
         not_existing_string_list = ['Restarting application']
     else:
-        not_existing_string_list=None
+        not_existing_string_list = None
 
     # Execute `tns run` and wait until logs are OK
     result = run_hello_world_js_ts(app_name=app_name, platform=platform, device=device, bundle=bundle, hmr=hmr,
@@ -100,14 +100,16 @@ def __sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=True, 
     device.wait_for_text(text=js_change.old_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    hmr=hmr, file_name='app.css', instrumented=instrumented, device=device)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, not_existing_string_list=not_existing_string_list)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
+                         not_existing_string_list=not_existing_string_list)
 
     # Edit JS file and verify changes are applied
     Sync.replace(app_name=app_name, change_set=js_change)
     device.wait_for_text(text=js_change.new_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    hmr=hmr, file_name=js_file, instrumented=instrumented, device=device)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, not_existing_string_list=not_existing_string_list)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
+                         not_existing_string_list=not_existing_string_list)
 
     # Edit XML file and verify changes are applied
     Sync.replace(app_name=app_name, change_set=xml_change)
@@ -115,7 +117,8 @@ def __sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=True, 
     device.wait_for_text(text=js_change.new_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    hmr=hmr, file_name='main-page.xml', instrumented=instrumented, device=device)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, not_existing_string_list=not_existing_string_list)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
+                         not_existing_string_list=not_existing_string_list)
 
     # Revert all the changes
     Sync.revert(app_name=app_name, change_set=js_change)
@@ -123,14 +126,16 @@ def __sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=True, 
     device.wait_for_text(text=xml_change.new_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    hmr=hmr, file_name=js_file, instrumented=instrumented, device=device)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, not_existing_string_list=not_existing_string_list)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
+                         not_existing_string_list=not_existing_string_list)
 
     Sync.revert(app_name=app_name, change_set=xml_change)
     device.wait_for_text(text=xml_change.old_text)
     device.wait_for_text(text=js_change.old_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    hmr=hmr, file_name='main-page.xml', instrumented=instrumented, device=device)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, not_existing_string_list=not_existing_string_list)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
+                         not_existing_string_list=not_existing_string_list)
 
     Sync.revert(app_name=app_name, change_set=css_change)
     device.wait_for_color(color=Colors.LIGHT_BLUE, pixel_count=blue_count)
@@ -138,7 +143,8 @@ def __sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=True, 
     device.wait_for_text(text=js_change.old_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    hmr=hmr, file_name='app.css', instrumented=instrumented, device=device)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, not_existing_string_list=not_existing_string_list)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
+                         not_existing_string_list=not_existing_string_list)
 
     # Assert final and initial states are same
     initial_state = os.path.join(Settings.TEST_OUT_IMAGES, device.name, 'initial_state.png')

--- a/data/sync/hello_world_js.py
+++ b/data/sync/hello_world_js.py
@@ -85,6 +85,8 @@ def __sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=True, 
     # Verify that application is not restarted on file changes when hmr=true
     if hmr:
         not_existing_string_list = ['Restarting application']
+    else:
+        not_existing_string_list=None
 
     # Execute `tns run` and wait until logs are OK
     result = run_hello_world_js_ts(app_name=app_name, platform=platform, device=device, bundle=bundle, hmr=hmr,

--- a/data/sync/hello_world_js.py
+++ b/data/sync/hello_world_js.py
@@ -82,6 +82,10 @@ def __sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=True, 
     else:
         raise ValueError('Invalid app_type value.')
 
+    # Verify that application is not restarted on file changes when hmr=true
+    if hmr:
+        not_existing_string_list = ['Restarting application']
+
     # Execute `tns run` and wait until logs are OK
     result = run_hello_world_js_ts(app_name=app_name, platform=platform, device=device, bundle=bundle, hmr=hmr,
                                    uglify=uglify, aot=aot, snapshot=snapshot, default_andr_sdk=default_andr_sdk)
@@ -94,14 +98,14 @@ def __sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=True, 
     device.wait_for_text(text=js_change.old_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    hmr=hmr, file_name='app.css', instrumented=instrumented, device=device)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, not_existing_string_list=not_existing_string_list)
 
     # Edit JS file and verify changes are applied
     Sync.replace(app_name=app_name, change_set=js_change)
     device.wait_for_text(text=js_change.new_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    hmr=hmr, file_name=js_file, instrumented=instrumented, device=device)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, not_existing_string_list=not_existing_string_list)
 
     # Edit XML file and verify changes are applied
     Sync.replace(app_name=app_name, change_set=xml_change)
@@ -109,7 +113,7 @@ def __sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=True, 
     device.wait_for_text(text=js_change.new_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    hmr=hmr, file_name='main-page.xml', instrumented=instrumented, device=device)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, not_existing_string_list=not_existing_string_list)
 
     # Revert all the changes
     Sync.revert(app_name=app_name, change_set=js_change)
@@ -117,14 +121,14 @@ def __sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=True, 
     device.wait_for_text(text=xml_change.new_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    hmr=hmr, file_name=js_file, instrumented=instrumented, device=device)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, not_existing_string_list=not_existing_string_list)
 
     Sync.revert(app_name=app_name, change_set=xml_change)
     device.wait_for_text(text=xml_change.old_text)
     device.wait_for_text(text=js_change.old_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    hmr=hmr, file_name='main-page.xml', instrumented=instrumented, device=device)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, not_existing_string_list=not_existing_string_list)
 
     Sync.revert(app_name=app_name, change_set=css_change)
     device.wait_for_color(color=Colors.LIGHT_BLUE, pixel_count=blue_count)
@@ -132,7 +136,7 @@ def __sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=True, 
     device.wait_for_text(text=js_change.old_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    hmr=hmr, file_name='app.css', instrumented=instrumented, device=device)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, not_existing_string_list=not_existing_string_list)
 
     # Assert final and initial states are same
     initial_state = os.path.join(Settings.TEST_OUT_IMAGES, device.name, 'initial_state.png')

--- a/data/sync/hello_world_ng.py
+++ b/data/sync/hello_world_ng.py
@@ -141,6 +141,7 @@ def preview_sync_hello_world_ng(app_name, platform, device, bundle=True, hmr=Tru
     result = preview_hello_world_ng(app_name=app_name, platform=platform, device=device, bundle=bundle, hmr=hmr,
                                     instrumented=instrumented, click_open_alert=click_open_alert)
 
+    # Verify that application is not restarted on file changes when hmr=true
     if hmr:
         not_existing_string_list = ['Restarting application']
     else:

--- a/data/sync/hello_world_ng.py
+++ b/data/sync/hello_world_ng.py
@@ -51,7 +51,7 @@ def sync_hello_world_ng(app_name, platform, device, bundle=True, uglify=False, a
     if hmr:
         not_existing_string_list = ['Restarting application']
     else:
-        not_existing_string_list=None
+        not_existing_string_list = None
 
     # Apply changes
     Sync.replace(app_name=app_name, change_set=Changes.NGHelloWorld.TS)
@@ -145,7 +145,7 @@ def preview_sync_hello_world_ng(app_name, platform, device, bundle=True, hmr=Tru
     if hmr:
         not_existing_string_list = ['Restarting application']
     else:
-        not_existing_string_list=None
+        not_existing_string_list = None
 
     # Edit TS file and verify changes are applied
     Sync.replace(app_name=app_name, change_set=Changes.NGHelloWorld.TS)

--- a/data/sync/hello_world_ng.py
+++ b/data/sync/hello_world_ng.py
@@ -50,6 +50,8 @@ def sync_hello_world_ng(app_name, platform, device, bundle=True, uglify=False, a
     # Verify that application is not restarted on file changes when hmr=true
     if hmr:
         not_existing_string_list = ['Restarting application']
+    else:
+        not_existing_string_list=None
 
     # Apply changes
     Sync.replace(app_name=app_name, change_set=Changes.NGHelloWorld.TS)
@@ -141,6 +143,8 @@ def preview_sync_hello_world_ng(app_name, platform, device, bundle=True, hmr=Tru
 
     if hmr:
         not_existing_string_list = ['Restarting application']
+    else:
+        not_existing_string_list=None
 
     # Edit TS file and verify changes are applied
     Sync.replace(app_name=app_name, change_set=Changes.NGHelloWorld.TS)

--- a/data/sync/hello_world_ng.py
+++ b/data/sync/hello_world_ng.py
@@ -47,13 +47,18 @@ def sync_hello_world_ng(app_name, platform, device, bundle=True, uglify=False, a
                         instrumented=True):
     result = run_hello_world_ng(app_name=app_name, platform=platform, device=device, uglify=uglify, aot=aot, hmr=hmr)
 
+    # Verify that application is not restarted on file changes when hmr=true
+    if hmr:
+        not_existing_string_list = ['Restarting application']
+
     # Apply changes
     Sync.replace(app_name=app_name, change_set=Changes.NGHelloWorld.TS)
     device.wait_for_text(text=Changes.NGHelloWorld.TS.new_text)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    file_name='item.service.ts', hmr=hmr, instrumented=instrumented, app_type=AppType.NG,
                                    device=device)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180,
+                         not_existing_string_list=not_existing_string_list)
 
     Sync.replace(app_name=app_name, change_set=Changes.NGHelloWorld.HTML)
     if platform == Platform.IOS:
@@ -66,7 +71,8 @@ def sync_hello_world_ng(app_name, platform, device, bundle=True, uglify=False, a
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    file_name='items.component.html', hmr=hmr, instrumented=instrumented,
                                    app_type=AppType.NG, aot=aot, device=device)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180,
+                         not_existing_string_list=not_existing_string_list)
 
     Sync.replace(app_name=app_name, change_set=Changes.NGHelloWorld.CSS)
     device.wait_for_main_color(color=Colors.DARK)
@@ -80,7 +86,8 @@ def sync_hello_world_ng(app_name, platform, device, bundle=True, uglify=False, a
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    file_name='app.css', hmr=hmr, instrumented=instrumented, app_type=AppType.NG,
                                    device=device)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180,
+                         not_existing_string_list=not_existing_string_list)
 
     # Revert changes
     Sync.revert(app_name=app_name, change_set=Changes.NGHelloWorld.HTML)
@@ -88,7 +95,8 @@ def sync_hello_world_ng(app_name, platform, device, bundle=True, uglify=False, a
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    file_name='items.component.html', hmr=hmr, instrumented=instrumented,
                                    app_type=AppType.NG, aot=aot, device=device)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180,
+                         not_existing_string_list=not_existing_string_list)
 
     Sync.revert(app_name=app_name, change_set=Changes.NGHelloWorld.TS)
     device.wait_for_text(text=Changes.NGHelloWorld.TS.old_text)
@@ -96,7 +104,8 @@ def sync_hello_world_ng(app_name, platform, device, bundle=True, uglify=False, a
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    file_name='item.service.ts', hmr=hmr, instrumented=instrumented, app_type=AppType.NG,
                                    device=device)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180,
+                         not_existing_string_list=not_existing_string_list)
 
     Sync.revert(app_name=app_name, change_set=Changes.NGHelloWorld.CSS)
     device.wait_for_main_color(color=Colors.WHITE)
@@ -104,7 +113,8 @@ def sync_hello_world_ng(app_name, platform, device, bundle=True, uglify=False, a
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                    file_name='app.css', hmr=hmr, instrumented=instrumented, app_type=AppType.NG,
                                    device=device)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180,
+                         not_existing_string_list=not_existing_string_list)
 
     # Assert final and initial states are same
     initial_state = os.path.join(Settings.TEST_OUT_IMAGES, device.name, 'initial_state.png')
@@ -129,18 +139,23 @@ def preview_sync_hello_world_ng(app_name, platform, device, bundle=True, hmr=Tru
     result = preview_hello_world_ng(app_name=app_name, platform=platform, device=device, bundle=bundle, hmr=hmr,
                                     instrumented=instrumented, click_open_alert=click_open_alert)
 
+    if hmr:
+        not_existing_string_list = ['Restarting application']
+
     # Edit TS file and verify changes are applied
     Sync.replace(app_name=app_name, change_set=Changes.NGHelloWorld.TS)
     strings = TnsLogs.preview_file_changed_messages(platform=platform, run_type=RunType.INCREMENTAL, bundle=bundle,
                                                     file_name='item.service.ts', hmr=hmr, instrumented=instrumented)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180,
+                         not_existing_string_list=not_existing_string_list)
     device.wait_for_text(text=Changes.NGHelloWorld.TS.new_text)
 
     # Edit HTML file and verify changes are applied
     Sync.replace(app_name=app_name, change_set=Changes.NGHelloWorld.HTML)
     strings = TnsLogs.preview_file_changed_messages(platform=platform, bundle=bundle, file_name='items.component.html',
                                                     hmr=hmr, instrumented=instrumented)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180,
+                         not_existing_string_list=not_existing_string_list)
     if platform == Platform.IOS:
         for number in ["10", "1"]:
             device.wait_for_text(text=number)
@@ -153,7 +168,8 @@ def preview_sync_hello_world_ng(app_name, platform, device, bundle=True, hmr=Tru
     Sync.replace(app_name=app_name, change_set=Changes.NGHelloWorld.CSS)
     strings = TnsLogs.preview_file_changed_messages(platform=platform, bundle=bundle, file_name='app.css',
                                                     hmr=hmr, instrumented=instrumented)
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180,
+                         not_existing_string_list=not_existing_string_list)
     device.wait_for_main_color(color=Colors.DARK)
     if platform == Platform.IOS:
         for number in ["10", "1"]:

--- a/data/sync/master_detail_vue.py
+++ b/data/sync/master_detail_vue.py
@@ -40,7 +40,7 @@ def sync_master_detail_vue(app_name, platform, device, bundle=True, hmr=True):
     if hmr:
         not_existing_string_list = ['Restarting application']
     else:
-        not_existing_string_list=None
+        not_existing_string_list = None
 
     # Edit template in .vue file
     Sync.replace(app_name=app_name, change_set=Changes.MasterDetailVUE.VUE_TEMPLATE)

--- a/data/sync/master_detail_vue.py
+++ b/data/sync/master_detail_vue.py
@@ -36,18 +36,24 @@ def sync_master_detail_vue(app_name, platform, device, bundle=True, hmr=True):
     initial_state = os.path.join(Settings.TEST_OUT_IMAGES, device.name, 'initial_state.png')
     device.get_screen(path=initial_state)
 
+    # Verify that application is not restarted on file changes when hmr=true
+    if hmr:
+        not_existing_string_list = ['Restarting application']
+
     # Edit template in .vue file
     Sync.replace(app_name=app_name, change_set=Changes.MasterDetailVUE.VUE_TEMPLATE)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL,
                                    bundle=bundle, hmr=hmr, app_type=AppType.VUE, file_name='CarList.vue')
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
+                         not_existing_string_list=not_existing_string_list)
     device.wait_for_text(text=Changes.MasterDetailVUE.VUE_TEMPLATE.new_text)
 
     # Edit styling in .vue file
     Sync.replace(app_name=app_name, change_set=Changes.MasterDetailVUE.VUE_STYLE)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL,
                                    bundle=bundle, hmr=hmr, app_type=AppType.VUE, file_name='CarList.vue')
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
+                         not_existing_string_list=not_existing_string_list)
     style_applied = Wait.until(lambda: device.get_pixels_by_color(Colors.RED_DARK) > 200)
     assert style_applied, 'Failed to sync changes in style.'
 
@@ -55,7 +61,8 @@ def sync_master_detail_vue(app_name, platform, device, bundle=True, hmr=True):
     Sync.revert(app_name=app_name, change_set=Changes.MasterDetailVUE.VUE_STYLE)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL,
                                    bundle=bundle, hmr=hmr, app_type=AppType.VUE, file_name='CarList.vue')
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
+                         not_existing_string_list=not_existing_string_list)
     style_applied = Wait.until(lambda: device.get_pixels_by_color(Colors.WHITE) > 200)
     assert style_applied, 'Failed to sync changes in style.'
 
@@ -70,7 +77,8 @@ def sync_master_detail_vue(app_name, platform, device, bundle=True, hmr=True):
     Sync.replace(app_name=app_name, change_set=Changes.MasterDetailVUE.VUE_DETAIL_PAGE_TEMPLATE)
     strings = TnsLogs.run_messages(app_name=app_name, platform=platform, run_type=RunType.INCREMENTAL,
                                    bundle=bundle, hmr=hmr, app_type=AppType.VUE, file_name='CarDetails.vue')
-    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+    TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
+                         not_existing_string_list=not_existing_string_list)
     device.wait_for_text(text=Changes.MasterDetailVUE.VUE_DETAIL_PAGE_TEMPLATE.new_text)
 
     # Kill Appium

--- a/data/sync/master_detail_vue.py
+++ b/data/sync/master_detail_vue.py
@@ -39,6 +39,8 @@ def sync_master_detail_vue(app_name, platform, device, bundle=True, hmr=True):
     # Verify that application is not restarted on file changes when hmr=true
     if hmr:
         not_existing_string_list = ['Restarting application']
+    else:
+        not_existing_string_list=None
 
     # Edit template in .vue file
     Sync.replace(app_name=app_name, change_set=Changes.MasterDetailVUE.VUE_TEMPLATE)

--- a/tests/cli/device/test_run_on_device.py
+++ b/tests/cli/device/test_run_on_device.py
@@ -79,7 +79,17 @@ class TnsRunOnDevices(TnsDeviceTest):
         file_name = os.path.basename(Changes.JSHelloWord.JS.file_path)
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID, run_type=RunType.INCREMENTAL,
                                        file_name=file_name)
-        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings)
+        for device in DeviceManager.get_devices(device_type=any):
+            strings.append(device.id)
+        strings.append(self.emu.id)
+        if Settings.HOST_OS is OSType.OSX:
+            strings.append(self.sim.id)
+        
+        # Verify that application is not restarted on file changes when hmr=true
+        not_existing_string_list = ['Restarting application']
+
+        TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings,
+                             not_existing_string_list=not_existing_string_list)
 
         # Verify change is applied on all devices
         for device in DeviceManager.get_devices(device_type=any):

--- a/tests/cli/device/test_run_on_device.py
+++ b/tests/cli/device/test_run_on_device.py
@@ -60,10 +60,10 @@ class TnsRunOnDevices(TnsDeviceTest):
         # Wait for logs
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID, run_type=RunType.FULL)
         for device in DeviceManager.get_devices(device_type=any):
-            strings.append(device.id)
+            strings.append('Restarting application on device {0}'.format(device.id))
         strings.append(self.emu.id)
         if Settings.HOST_OS is OSType.OSX:
-            strings.append(self.sim.id)
+            strings.append('Restarting application on device {0}'.format(self.sim.id))
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=360)
 
         # Verify it looks properly
@@ -80,10 +80,10 @@ class TnsRunOnDevices(TnsDeviceTest):
         strings = TnsLogs.run_messages(app_name=self.app_name, platform=Platform.ANDROID, run_type=RunType.INCREMENTAL,
                                        file_name=file_name)
         for device in DeviceManager.get_devices(device_type=any):
-            strings.append(device.id)
+            strings.append('Refreshing application on device {0}'.format(device.id))
         strings.append(self.emu.id)
         if Settings.HOST_OS is OSType.OSX:
-            strings.append(self.sim.id)
+            strings.append('Refreshing application on device {0}'.format(self.sim.id))
         
         # Verify that application is not restarted on file changes when hmr=true
         not_existing_string_list = ['Restarting application']

--- a/tests/cli/device/test_run_on_device.py
+++ b/tests/cli/device/test_run_on_device.py
@@ -84,7 +84,7 @@ class TnsRunOnDevices(TnsDeviceTest):
         strings.append(self.emu.id)
         if Settings.HOST_OS is OSType.OSX:
             strings.append('Refreshing application on device {0}'.format(self.sim.id))
-        
+
         # Verify that application is not restarted on file changes when hmr=true
         not_existing_string_list = ['Restarting application']
 


### PR DESCRIPTION
When livesync with hmr, we verify changes are applied but don't always verify that the app is not restarted which is main hmr feature.
Fix: add asserts that `Restarting application` is not present in logs.