### PR TITLE
fix: win asserts

### DIFF
--- a/data/sync/blank_vue.py
+++ b/data/sync/blank_vue.py
@@ -47,7 +47,7 @@ def __workflow(preview, app_name, platform, device, bundle=True, hmr=True):
     device.get_screen(path=initial_state)
 
     # Verify that application is not restarted on file changes when hmr=true
-    if hmr:
+    if hmr and Settings.HOST_OS != OSType.WINDOWS:
         not_existing_string_list = ['Restarting application']
     else:
         not_existing_string_list = None

--- a/data/sync/blank_vue.py
+++ b/data/sync/blank_vue.py
@@ -4,6 +4,7 @@ Sync changes on JS/TS project helper.
 import os
 
 from core.enums.app_type import AppType
+from core.enums.os_type import OSType
 from core.log.log import Log
 from core.settings import Settings
 from core.utils.wait import Wait

--- a/data/sync/hello_world_js.py
+++ b/data/sync/hello_world_js.py
@@ -83,7 +83,7 @@ def __sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=True, 
         raise ValueError('Invalid app_type value.')
 
     # Verify that application is not restarted on file changes when hmr=true
-    if hmr:
+    if hmr and Settings.HOST_OS != OSType.WINDOWS:
         not_existing_string_list = ['Restarting application']
     else:
         not_existing_string_list = None

--- a/data/sync/hello_world_ng.py
+++ b/data/sync/hello_world_ng.py
@@ -7,6 +7,7 @@ import os
 from core.enums.app_type import AppType
 from core.enums.device_type import DeviceType
 from core.enums.platform_type import Platform
+from core.enums.os_type import OSType
 from core.settings import Settings
 from data.changes import Changes, Sync
 from data.const import Colors

--- a/data/sync/hello_world_ng.py
+++ b/data/sync/hello_world_ng.py
@@ -48,7 +48,7 @@ def sync_hello_world_ng(app_name, platform, device, bundle=True, uglify=False, a
     result = run_hello_world_ng(app_name=app_name, platform=platform, device=device, uglify=uglify, aot=aot, hmr=hmr)
 
     # Verify that application is not restarted on file changes when hmr=true
-    if hmr:
+    if hmr and Settings.HOST_OS != OSType.WINDOWS:
         not_existing_string_list = ['Restarting application']
     else:
         not_existing_string_list = None
@@ -142,7 +142,7 @@ def preview_sync_hello_world_ng(app_name, platform, device, bundle=True, hmr=Tru
                                     instrumented=instrumented, click_open_alert=click_open_alert)
 
     # Verify that application is not restarted on file changes when hmr=true
-    if hmr:
+    if hmr and Settings.HOST_OS != OSType.WINDOWS:
         not_existing_string_list = ['Restarting application']
     else:
         not_existing_string_list = None

--- a/data/sync/master_detail_vue.py
+++ b/data/sync/master_detail_vue.py
@@ -37,7 +37,7 @@ def sync_master_detail_vue(app_name, platform, device, bundle=True, hmr=True):
     device.get_screen(path=initial_state)
 
     # Verify that application is not restarted on file changes when hmr=true
-    if hmr:
+    if hmr and Settings.HOST_OS != OSType.WINDOWS:
         not_existing_string_list = ['Restarting application']
     else:
         not_existing_string_list = None

--- a/data/sync/master_detail_vue.py
+++ b/data/sync/master_detail_vue.py
@@ -7,6 +7,7 @@ from selenium.webdriver.common.by import By
 
 from core.enums.app_type import AppType
 from core.enums.platform_type import Platform
+from core.enums.os_type import OSType
 from core.settings import Settings
 from core.utils.appium.appium_driver import AppiumDriver
 from core.utils.wait import Wait


### PR DESCRIPTION
On windows our waitForLog logic is not working as expected. In result `Restarting application` is found in log from the initial run of the app which is causing fails.
Fix: skip that check for hmr on windows