### PR TITLE
fix: aab test

### DIFF
--- a/tests/cli/build/android_app_bundle_tests.py
+++ b/tests/cli/build/android_app_bundle_tests.py
@@ -85,7 +85,7 @@ class AndroidAppBundleTests(TnsRunAndroidTest):
 
         # Verify app can be deployed on emulator via nativescript
         # Verify app looks correct inside emulator
-        self.emu.wait_for_text(text='TAP')
+        self.emu.wait_for_text(text='TAP', timeout=240)
 
         # Verify that the correct .so file is included in the package
         File.unzip(path_to_apks, os.path.join(self.app_name, 'apks'))


### PR DESCRIPTION
Due to this issue: https://github.com/NativeScript/nativescript-cli/issues/5103
when aab test runs on machine with devices the test takes more time to finish, because second build is triggered.
To workaround the problem until the issue is fixed we can wait more time to verify app is deployed.