### PR TITLE
feat: enable not strict ios simulator versions

### DIFF
--- a/core/settings/Settings.py
+++ b/core/settings/Settings.py
@@ -193,10 +193,10 @@ Emulators.DEFAULT = resolve_default_emulator("EMULATOR_API_VERSION", Emulators.E
 
 
 class Simulators(object):
-    SIM_IOS10 = SimulatorInfo(name=os.environ.get('SIM_IOS10', 'iPhone7_10'), device_type='iPhone 7', sdk=10.0)
-    SIM_IOS11 = SimulatorInfo(name=os.environ.get('SIM_IOS11', 'iPhone7_11'), device_type='iPhone 7', sdk=11.2)
-    SIM_IOS12 = SimulatorInfo(name=os.environ.get('SIM_IOS12', 'iPhoneXR_12'), device_type='iPhone XR', sdk=12.0)
-    SIM_IOS13 = SimulatorInfo(name=os.environ.get('SIM_IOS13', 'iPhoneXR_13'), device_type='iPhone XR', sdk=13.1)
+    SIM_IOS10 = SimulatorInfo(name=os.environ.get('SIM_IOS10', 'iPhone7_10'), device_type='iPhone 7', sdk=10)
+    SIM_IOS11 = SimulatorInfo(name=os.environ.get('SIM_IOS11', 'iPhone7_11'), device_type='iPhone 7', sdk=11)
+    SIM_IOS12 = SimulatorInfo(name=os.environ.get('SIM_IOS12', 'iPhoneXR_12'), device_type='iPhone XR', sdk=12)
+    SIM_IOS13 = SimulatorInfo(name=os.environ.get('SIM_IOS13', 'iPhoneXR_13'), device_type='iPhone XR', sdk=13)
     DEFAULT = SIM_IOS12
 
 

--- a/core/utils/device/device_manager.py
+++ b/core/utils/device/device_manager.py
@@ -129,8 +129,9 @@ class DeviceManager(object):
     class Simulator(object):
         @staticmethod
         def create(simulator_info):
+            exact_sdk_verson = Simctl.get_max_runtime_version(simulator_info.sdk)
             cmd = 'xcrun simctl create {0} "{1}" com.apple.CoreSimulator.SimRuntime.iOS-{2}' \
-                .format(simulator_info.name, simulator_info.device_type, str(simulator_info.sdk).replace('.', '-'))
+                .format(simulator_info.name, simulator_info.device_type, exact_sdk_verson.replace('.', '-'))
             result = run(cmd=cmd, timeout=60)
             assert result.exit_code == 0, 'Failed to create iOS Simulator with name {0}'.format(simulator_info.name)
             assert '-' in result.output, 'Failed to create iOS Simulator with name {0}'.format(simulator_info.name)

--- a/core/utils/device/simctl.py
+++ b/core/utils/device/simctl.py
@@ -41,7 +41,7 @@ class Simctl(object):
         # Get max runtime version
         exact_sdk_version = None
         for runtime in runtimes['runtimes']:
-            if str(version) in runtime['version']:
+            if str(version) in runtime['version'] and runtime['name'].startswith('iOS') and runtime['isAvailable']:
                 exact_sdk_version = runtime['version']
         if exact_sdk_version is None:
             raise Exception('Can not find iOS SDK {0}'.format(version))

--- a/core/utils/device/simctl.py
+++ b/core/utils/device/simctl.py
@@ -26,6 +26,39 @@ class Simctl(object):
             Log.error('Failed to parse json ' + os.linesep + result.output)
             return json.loads('{}')
 
+    # noinspection PyBroadException
+    @staticmethod
+    def get_max_runtime_version(version):
+        # Parse runtimes
+        result = Simctl.run_simctl_command(command='list --json runtimes')
+        runtimes = None
+        try:
+            runtimes = json.loads(result.output)
+        except ValueError:
+            Log.error('Failed to parse json ' + os.linesep + result.output)
+            return json.loads('{}')
+
+        # Get max runtime version
+        exact_sdk_version = None
+        for runtime in runtimes['runtimes']:
+            if str(version) in runtime['version']:
+                exact_sdk_version = runtime['version']
+        if exact_sdk_version is None:
+            raise Exception('Can not find iOS SDK {0}'.format(version))
+
+        return exact_sdk_version
+
+    @staticmethod
+    def __get_devices_by_version(version):
+        exact_sdk_version = Simctl.get_max_runtime_version(version)
+        devices = Simctl.__get_simulators()['devices']
+        placeholder = 'iOS {0}'
+        device_key = placeholder.format(exact_sdk_version)
+        if device_key not in devices:
+            placeholder_dash = placeholder.format(exact_sdk_version).replace(' ', '-').replace('.', '-')
+            device_key = 'com.apple.CoreSimulator.SimRuntime.{0}'.format(placeholder_dash)
+        return devices[device_key]
+
     @staticmethod
     def __get_availability(sim):
         available = False
@@ -46,14 +79,7 @@ class Simctl(object):
 
     @staticmethod
     def is_running(simulator_info):
-        devices = Simctl.__get_simulators()['devices']
-        placeholder = 'iOS {0}'
-        device_key = placeholder.format(simulator_info.sdk)
-        if device_key not in devices:
-            placeholder_dash = placeholder.format(simulator_info.sdk).replace(' ', '-').replace('.', '-')
-            device_key = 'com.apple.CoreSimulator.SimRuntime.{0}'.format(placeholder_dash)
-        sims = devices[device_key]
-        for sim in sims:
+        for sim in Simctl.__get_devices_by_version(simulator_info.sdk):
             if sim['name'] == simulator_info.name and sim['state'] == 'Booted':
                 # simctl returns Booted too early, so we will wait some untill service is started
                 simulator_info.id = str(sim['udid'])
@@ -85,14 +111,7 @@ class Simctl(object):
 
     @staticmethod
     def is_available(simulator_info):
-        devices = Simctl.__get_simulators()['devices']
-        placeholder = 'iOS {0}'
-        device_key = placeholder.format(simulator_info.sdk)
-        if device_key not in devices:
-            placeholder_dash = placeholder.format(simulator_info.sdk).replace(' ', '-').replace('.', '-')
-            device_key = 'com.apple.CoreSimulator.SimRuntime.{0}'.format(placeholder_dash)
-        sims = devices[device_key]
-        for sim in sims:
+        for sim in Simctl.__get_devices_by_version(simulator_info.sdk):
             if sim['name'] == simulator_info.name and Simctl.__get_availability(sim):
                 simulator_info.id = str(sim['udid'])
                 return simulator_info


### PR DESCRIPTION
Enable not strict iOS simulator versions.

Reason behind this:
- Xcode 11 do not provide older version of iOS13 except latest
- That cause variaty of iOS 13.0, 13.1, 13.2 and so on versions on different machines (it may be machine of external contributor as well)
- We need to give a chance for everyone to run those tests instead of hardcoding fixed version.