### PR TITLE
chore: address changes caused by new templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 package-lock.json
 nosetests.*
 node_modules
+Test App
 TestApp*
 out/*
 /data/temp

--- a/assets/myCustomTemplate/package.json
+++ b/assets/myCustomTemplate/package.json
@@ -3,11 +3,10 @@
   "version": "1.0.0",
   "dependencies": {
     "lodash": "3.10.1",
-    "nativescript-theme-core": "~1.0.2"
+    "@nativescript/theme": "~2.2.0"
   },
   "devDependencies": {
     "minimist": "1.2.0",
-    "nativescript-dev-android-snapshot": "^0.*.*",
     "nativescript-dev-webpack": "^0.20.0"
   },
   "description": "dummy",

--- a/core_tests/unit/utils/wait_tests.py
+++ b/core_tests/unit/utils/wait_tests.py
@@ -21,7 +21,7 @@ class WaitTests(unittest.TestCase):
     @timed(5)
     def test_20_get_average_time(self):
         ls_time = PerfUtils.get_average_time(lambda: run(cmd='ifconfig'), retry_count=5)
-        assert 0.003 <= ls_time <= 0.03, "Command not executed in acceptable time. Actual value: " + str(ls_time)
+        assert 0.005 <= ls_time <= 0.05, "Command not executed in acceptable time. Actual value: " + str(ls_time)
 
     @staticmethod
     def seconds_are_odd():

--- a/data/changes.py
+++ b/data/changes.py
@@ -36,7 +36,7 @@ class Changes(object):
         CSS = ChangeSet(file_path=os.path.join('app', 'app.css'),
                         old_value='font-size: 18',
                         new_value='font-size: 18;\nbackground-color: red;',
-                        old_color=None, new_color=None)
+                        old_color=None, new_color=Colors.RED)
         XML = ChangeSet(file_path=os.path.join('app', 'main-page.xml'),
                         old_value='TAP', new_value='HIT',
                         old_text='TAP', new_text='HIT')

--- a/data/changes.py
+++ b/data/changes.py
@@ -56,7 +56,7 @@ class Changes(object):
         CSS = ChangeSet(file_path=os.path.join('app', 'app.css'),
                         old_value='font-size: 18',
                         new_value='font-size: 18;\nbackground-color: red;',
-                        old_color=None, new_color=None)
+                        old_color=None, new_color=Colors.RED)
         XML = ChangeSet(file_path=os.path.join('app', 'main-page.xml'),
                         old_value='TAP', new_value='HIT',
                         old_text='TAP', new_text='HIT')

--- a/data/sync/hello_world_js.py
+++ b/data/sync/hello_world_js.py
@@ -13,8 +13,8 @@ from data.const import Colors
 from products.nativescript.preview_helpers import Preview
 from products.nativescript.run_type import RunType
 from products.nativescript.tns import Tns
-from products.nativescript.tns_logs import TnsLogs
 from products.nativescript.tns_assert import TnsAssert
+from products.nativescript.tns_logs import TnsLogs
 from products.nativescript.tns_paths import TnsPaths
 
 
@@ -198,7 +198,7 @@ def preview_sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=
                              not_existing_string_list=not_existing_string_list)
     else:
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=90)
-    device.wait_for_color(color=Colors.LIGHT_BLUE, pixel_count=blue_count * 2, delta=25)
+    device.wait_for_color(color=Colors.RED, pixel_count=blue_count, delta=25)
 
     # Edit JS file and verify changes are applied
     Sync.replace(app_name=app_name, change_set=js_change)

--- a/data/sync/hello_world_js.py
+++ b/data/sync/hello_world_js.py
@@ -185,6 +185,7 @@ def preview_sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=
     else:
         raise ValueError('Invalid app_type value.')
 
+    not_existing_string_list = None
     if hmr and instrumented:
         not_existing_string_list = ['QA: Application started']
 

--- a/data/sync/hello_world_js.py
+++ b/data/sync/hello_world_js.py
@@ -198,7 +198,7 @@ def preview_sync_hello_world_js_ts(app_type, app_name, platform, device, bundle=
                              not_existing_string_list=not_existing_string_list)
     else:
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=90)
-    device.wait_for_color(color=Colors.RED, pixel_count=blue_count, delta=25)
+    device.wait_for_color(color=css_change.new_color, pixel_count=blue_count, delta=25)
 
     # Edit JS file and verify changes are applied
     Sync.replace(app_name=app_name, change_set=js_change)

--- a/data/sync/hello_world_ng.py
+++ b/data/sync/hello_world_ng.py
@@ -90,7 +90,7 @@ def sync_hello_world_ng(app_name, platform, device, bundle=True, uglify=False, a
                                    device=device)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180,
                          not_existing_string_list=not_existing_string_list)
-    device.wait_for_main_color(color=Colors.PINK)
+    device.wait_for_main_color(color=Changes.NGHelloWorld.CSS.new_color)
 
     # Revert changes
     Sync.revert(app_name=app_name, change_set=Changes.NGHelloWorld.HTML)
@@ -175,7 +175,7 @@ def preview_sync_hello_world_ng(app_name, platform, device, bundle=True, hmr=Tru
                                                     hmr=hmr, instrumented=instrumented)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180,
                          not_existing_string_list=not_existing_string_list)
-    device.wait_for_main_color(color=Colors.DARK)
+    device.wait_for_main_color(color=Changes.NGHelloWorld.CSS.new_color)
     if platform == Platform.IOS:
         for number in ["10", "1"]:
             device.wait_for_text(text=number)

--- a/products/nativescript/tns.py
+++ b/products/nativescript/tns.py
@@ -165,7 +165,7 @@ class Tns(object):
         TestContext.TEST_APP_NAME = app_name
 
         # Verify app is created properly
-        if verify is not False:
+        if verify:
             # Usually we do not pass path on tns create, which actually equals to cwd.
             # In such cases pass correct path to TnsAssert.created()
             if path is None:

--- a/tests/apps/apps_tests.py
+++ b/tests/apps/apps_tests.py
@@ -25,8 +25,7 @@ class SampleAppsTests(TnsTest):
         ('nativescript-sdk-examples-ng', 'NativeScript', 'NativeScript Code Samples'),
         ('nativescript-sdk-examples-js', 'NativeScript', 'Cookbook'),
         ('sample-Groceries', 'NativeScript', 'Login'),
-        # ('nativescript-marketplace-demo', 'NativeScript', 'GET STARTED'),
-        # Ignored because of https://github.com/NativeScript/nativescript-marketplace-demo/issues/301
+        ('nativescript-marketplace-demo', 'NativeScript', 'GET STARTED'),
     ]
 
     @classmethod

--- a/tests/cli/create/create.md
+++ b/tests/cli/create/create.md
@@ -1,4 +1,0 @@
-#Tests to be writen
-
-**create and init**
-https://github.com/NativeScript/nativescript-cli/tree/master/docs/man_pages/project/creation

--- a/tests/cli/create/create_tests.py
+++ b/tests/cli/create/create_tests.py
@@ -9,6 +9,8 @@ from data.apps import Apps
 from data.templates import Template
 from products.nativescript.app import App
 from products.nativescript.tns import Tns
+# noinspection PyMethodMayBeStatic
+from products.nativescript.tns_assert import TnsAssert
 
 
 # noinspection PyMethodMayBeStatic
@@ -117,7 +119,8 @@ class CreateTests(TnsTest):
     ])
     def test_200_create_project_with_template(self, template_source):
         """Create app should be possible with --template and npm packages, git repos and aliases"""
-        Tns.create(app_name=Settings.AppName.DEFAULT, template=template_source, update=False)
+        result = Tns.create(app_name=Settings.AppName.DEFAULT, template=template_source, update=False, verify=False)
+        TnsAssert.created(app_name=Settings.AppName.DEFAULT, output=result.output, theme=False)
 
     def test_201_create_project_with_local_directory_template(self):
         """--template should install all packages from package.json"""

--- a/tests/cli/create/create_tests.py
+++ b/tests/cli/create/create_tests.py
@@ -9,7 +9,6 @@ from data.apps import Apps
 from data.templates import Template
 from products.nativescript.app import App
 from products.nativescript.tns import Tns
-# noinspection PyMethodMayBeStatic
 from products.nativescript.tns_assert import TnsAssert
 
 
@@ -31,9 +30,7 @@ class CreateTests(TnsTest):
 
     def test_001_create_app_like_real_user(self):
         """Create app with no any params"""
-        # webpack - remove template after merge
-        Tns.create(app_name=Settings.AppName.DEFAULT, app_data=Apps.HELLO_WORLD_JS,
-                   template=Template.HELLO_WORLD_JS.local_package, update=False)
+        Tns.create(app_name=Settings.AppName.DEFAULT, app_data=Apps.HELLO_WORLD_JS, update=False)
 
     def test_002_create_app_template_js(self):
         """Create app with --template js project"""

--- a/tests/cli/resources/test_resource_generation.py
+++ b/tests/cli/resources/test_resource_generation.py
@@ -53,7 +53,7 @@ class ResourcesGenerateTests(TnsTest):
     def test_301_tns_resources_generate_icons_old_template_structure(self):
         # Create nativescript@4 app
         result = Tns.create(app_name=APP_NAME, template='tns-template-hello-world@4.0', verify=False)
-        TnsAssert.created(app_name=APP_NAME, output=result.output, webpack=False)
+        TnsAssert.created(app_name=APP_NAME, output=result.output, webpack=False, theme=False)
 
         # Generate icons with nativescript
         self.test_001_tns_resources_generate_icons()

--- a/tests/cli/resources/test_resource_update.py
+++ b/tests/cli/resources/test_resource_update.py
@@ -17,7 +17,7 @@ class ResourcesUpdateTests(TnsTest):
     def test_300_tns_resources_update(self):
         # Create nativescript@3 app
         result = Tns.create(app_name=APP_NAME, template='tns-template-hello-world@3.0', verify=False, update=False)
-        TnsAssert.created(app_name=APP_NAME, output=result.output, webpack=False)
+        TnsAssert.created(app_name=APP_NAME, output=result.output, webpack=False, theme=False)
 
         # Update resources
         out = Tns.exec_command(command='resources update', path=APP_NAME).output

--- a/tests/cli/run/tests/run_tests.py
+++ b/tests/cli/run/tests/run_tests.py
@@ -237,16 +237,17 @@ class TnsRunJSTests(TnsRunTest):
         assert blue_count > 100, 'Failed to find blue color on {0}'.format(self.emu.name)
 
         Tns.kill()
+
         # Make changes in js, css and xml files
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.JS)
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.XML)
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.CSS)
 
         # Run with --release again and verify changes are deployed on device
-        result = Tns.run_android(app_name=self.app_name, release=True, verify=True, emulator=True)
+        Tns.run_android(app_name=self.app_name, release=True, verify=True, emulator=True)
         self.emu.wait_for_text(text=Changes.JSHelloWord.JS.new_text)
         self.emu.wait_for_text(text=Changes.JSHelloWord.XML.new_text)
-        self.emu.wait_for_color(color=Colors.LIGHT_BLUE, pixel_count=blue_count * 2, delta=25)
+        self.emu.wait_for_color(color=Colors.RED, pixel_count=blue_count, delta=25)
 
     @unittest.skipIf(Settings.HOST_OS != OSType.OSX, 'iOS tests can be executed only on macOS.')
     def test_110_tns_run_ios_release(self):
@@ -269,10 +270,10 @@ class TnsRunJSTests(TnsRunTest):
         Sync.replace(app_name=self.app_name, change_set=Changes.JSHelloWord.CSS)
 
         # Run with --release again and verify changes are deployed on device
-        result = Tns.run_ios(app_name=self.app_name, release=True, verify=True, emulator=True)
+        Tns.run_ios(app_name=self.app_name, release=True, verify=True, emulator=True)
         self.sim.wait_for_text(text=Changes.JSHelloWord.JS.new_text)
         self.sim.wait_for_text(text=Changes.JSHelloWord.XML.new_text)
-        self.sim.wait_for_color(color=Colors.LIGHT_BLUE, pixel_count=blue_count * 2, delta=25)
+        self.sim.wait_for_color(color=Colors.RED, pixel_count=blue_count, delta=25)
 
     @unittest.skipIf(Settings.HOST_OS == OSType.WINDOWS, 'skip on windows untill we fix wait_rof_log method')
     def test_115_tns_run_android_add_remove_files_and_folders(self):
@@ -425,8 +426,8 @@ class TnsRunJSTests(TnsRunTest):
         3. Incremental prepare is triggered if js, xml and css files are changed.
         """
         # Run app with --justlaunch and verify on device
-        result = run_hello_world_js_ts(self.app_name, Platform.IOS, self.sim, just_launch=True)
-        # On some machines it takes time for thr process to die
+        run_hello_world_js_ts(self.app_name, Platform.IOS, self.sim, just_launch=True)
+        # On some machines it takes time for the process to die
         time.sleep(5)
         assert not Process.is_running_by_commandline(Settings.Executables.TNS)
 
@@ -528,7 +529,7 @@ class TnsRunJSTests(TnsRunTest):
         If  set --clean rebuilds the native project
         """
         # Run the project once so it is build for the first time
-        result = run_hello_world_js_ts(self.app_name, Platform.IOS, self.sim, just_launch=True)
+        run_hello_world_js_ts(self.app_name, Platform.IOS, self.sim, just_launch=True)
 
         # Verify run --clean without changes rebuilds native project
         result = Tns.run_ios(app_name=self.app_name, verify=True, device=self.sim.id, clean=True, just_launch=True)
@@ -763,7 +764,7 @@ class TnsRunJSTests(TnsRunTest):
         https://github.com/NativeScript/nativescript-cli/issues/2170
         """
         # Deploy the app to make sure we have something at /data/data/org.nativescript.TestApp
-        result = run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, just_launch=True)
+        run_hello_world_js_ts(self.app_name, Platform.ANDROID, self.emu, just_launch=True)
 
         # Use all the disk space on emulator
         dest_file = '/data/data/' + TnsPaths.get_bundle_id(self.app_name)

--- a/tests/cli/run/tests/run_tests_api_28.py
+++ b/tests/cli/run/tests/run_tests_api_28.py
@@ -3,16 +3,17 @@ import os
 from core.base_test.tns_run_android_test import TnsRunAndroidTest
 from core.enums.platform_type import Platform
 from core.settings import Settings
-from core.utils.file_utils import Folder
 from core.utils.docker import Docker
+from core.utils.file_utils import Folder
 from data.sync.hello_world_js import sync_hello_world_js, run_hello_world_js_ts
 from products.nativescript.tns import Tns
+from products.nativescript.tns_assert import TnsAssert
 from products.nativescript.tns_paths import TnsPaths
 
 Settings.Emulators.DEFAULT = Settings.Emulators.EMU_API_28
 
 
-class TnsRunJSTests(TnsRunAndroidTest):
+class TnsRunJSTestsApi28(TnsRunAndroidTest):
     app_name = Settings.AppName.DEFAULT
     source_project_dir = TnsPaths.get_app_path(app_name)
     target_project_dir = os.path.join(Settings.TEST_RUN_HOME, 'data', 'temp', app_name)
@@ -23,7 +24,8 @@ class TnsRunJSTests(TnsRunAndroidTest):
         Docker.start()
 
         # Create app
-        Tns.create(app_name=cls.app_name, template='tns-template-hello-world@6.0')
+        result = Tns.create(app_name=cls.app_name, template='tns-template-hello-world@6.0', verify=False)
+        TnsAssert.created(app_name=cls.app_name, output=result.output, path=Settings.TEST_RUN_HOME, theme=False)
 
         # Copy TestApp to data folder.
         Folder.copy(source=cls.source_project_dir, target=cls.target_project_dir)

--- a/tests/code_sharing/ng_new_tests.py
+++ b/tests/code_sharing/ng_new_tests.py
@@ -115,7 +115,9 @@ class NGNewTests(TnsRunTest):
                         sample=sample, style=style, prefix=prefix, source_dir=source_dir, webpack=webpack)
 
         # Verify valid {N} app is created
-        TnsAssert.created(app_name=NGNewTests.app_name, app_data=app_data, theme=theme, webpack=webpack)
+        # Temporary do not assert theme is created because in schematics we still use nativescript-theme-core@1
+        # TODO: Replace with theme=theme when schematics use @nativescript/theme
+        TnsAssert.created(app_name=NGNewTests.app_name, app_data=app_data, theme=False, webpack=webpack)
         assert 'Directory is already under version control. Skipping initialization of git.' in result.output, \
             'Git init should be skipped because app is created already existing repo (the one with tests).'
 

--- a/tests/code_sharing/test_ng_generate_e2e.py
+++ b/tests/code_sharing/test_ng_generate_e2e.py
@@ -55,7 +55,8 @@ class NGGenE2ETestsNS(TnsRunTest):
         app_path = TnsPaths.get_app_path(app_name=app_name)
         Folder.clean(app_path)
         NG.new(collection=NS_SCHEMATICS, project=app_name, shared=shared)
-        TnsAssert.created(app_name=app_name, app_data=None)
+        # TODO: Rollback theme=False when schematics use @nativescript/theme
+        TnsAssert.created(app_name=app_name, app_data=None, theme=False)
 
         # Run app initially
         text = 'TAP'

--- a/tests/code_sharing/test_ng_generate_ns.py
+++ b/tests/code_sharing/test_ng_generate_ns.py
@@ -24,7 +24,8 @@ class NGGenerateNGTests(TnsTest):
 
         # Create app
         NG.new(collection=NS_SCHEMATICS, project=cls.app_name, shared=False)
-        TnsAssert.created(app_name=cls.app_name, app_data=None)
+        # TODO: Rollback theme=False when schematics use @nativescript/theme
+        TnsAssert.created(app_name=cls.app_name, app_data=None, theme=False)
 
     def setUp(self):
         TnsTest.setUpClass()

--- a/tests/code_sharing/test_ng_generate_shared.py
+++ b/tests/code_sharing/test_ng_generate_shared.py
@@ -24,7 +24,8 @@ class NGGenerateSharedTests(TnsTest):
 
         # Create app
         NG.new(collection=NS_SCHEMATICS, project=cls.app_name, shared=True)
-        TnsAssert.created(app_name=cls.app_name, app_data=None)
+        # TODO: Rollback theme=False when schematics use @nativescript/theme
+        TnsAssert.created(app_name=cls.app_name, app_data=None, theme=False)
 
     def setUp(self):
         TnsTest.setUpClass()

--- a/tests/perf/app_size/test_app_size.py
+++ b/tests/perf/app_size/test_app_size.py
@@ -73,7 +73,7 @@ class AppSizeTests(TnsTest):
         # Verify content of APK
         assert PerfUtils.is_value_in_range(actual=Folder.get_size(lib), expected=51266016, tolerance=0.05)
         assert PerfUtils.is_value_in_range(actual=Folder.get_size(res), expected=796627, tolerance=0.05)
-        assert PerfUtils.is_value_in_range(actual=Folder.get_size(assets_app), expected=779471, tolerance=0.05)
+        assert PerfUtils.is_value_in_range(actual=Folder.get_size(assets_app), expected=839462, tolerance=0.05)
         assert PerfUtils.is_value_in_range(actual=Folder.get_size(assets_snapshots), expected=9042404, tolerance=0.05)
 
         # Verify final apk size
@@ -102,7 +102,7 @@ class AppSizeTests(TnsTest):
         assets_snapshots = os.path.join(extracted_apk, 'assets', 'snapshots')
 
         # No asserts for lib and res, since it is same as JS project
-        assert PerfUtils.is_value_in_range(actual=Folder.get_size(assets_app), expected=1538681, tolerance=0.05)
+        assert PerfUtils.is_value_in_range(actual=Folder.get_size(assets_app), expected=1636691, tolerance=0.05)
         assert PerfUtils.is_value_in_range(actual=Folder.get_size(assets_snapshots), expected=19890584, tolerance=0.05)
 
         # Verify final apk size

--- a/tests/perf/app_size/test_app_size.py
+++ b/tests/perf/app_size/test_app_size.py
@@ -74,7 +74,7 @@ class AppSizeTests(TnsTest):
         assert PerfUtils.is_value_in_range(actual=Folder.get_size(lib), expected=51266016, tolerance=0.05)
         assert PerfUtils.is_value_in_range(actual=Folder.get_size(res), expected=796627, tolerance=0.05)
         assert PerfUtils.is_value_in_range(actual=Folder.get_size(assets_app), expected=839462, tolerance=0.05)
-        assert PerfUtils.is_value_in_range(actual=Folder.get_size(assets_snapshots), expected=9042404, tolerance=0.05)
+        assert PerfUtils.is_value_in_range(actual=Folder.get_size(assets_snapshots), expected=10621384, tolerance=0.05)
 
         # Verify final apk size
         assert PerfUtils.is_value_in_range(actual=File.get_size(apk), expected=24304589, tolerance=0.03)
@@ -103,7 +103,7 @@ class AppSizeTests(TnsTest):
 
         # No asserts for lib and res, since it is same as JS project
         assert PerfUtils.is_value_in_range(actual=Folder.get_size(assets_app), expected=1636691, tolerance=0.05)
-        assert PerfUtils.is_value_in_range(actual=Folder.get_size(assets_snapshots), expected=19890584, tolerance=0.05)
+        assert PerfUtils.is_value_in_range(actual=Folder.get_size(assets_snapshots), expected=21822104, tolerance=0.05)
 
         # Verify final apk size
         assert PerfUtils.is_value_in_range(actual=File.get_size(apk), expected=26988067, tolerance=0.03)


### PR DESCRIPTION
- Fix create tests
- Fix preview tests
- Fix run `run_tests.py` and `run_tests_api_28.py`
- Fix resource update and generate tests
- Fix schematics tests
- Address changes in app size
- Add `Test App` in .gitignore
- Fix flaky unit test causing PRs in this repo to fail.
- Enable `nativescript-marketplace-demo` ignored tests