### PR TITLE
fix: docker on win

### DIFF
--- a/core/utils/docker.py
+++ b/core/utils/docker.py
@@ -13,27 +13,24 @@ class Docker(object):
     def start():
         if Settings.HOST_OS == OSType.WINDOWS:
             docker = os.environ.get("DOCKER_HOME")
-            if docker is not None:
-                cmd = '"' + os.path.join(docker, 'Docker Desktop.exe') + '"'
-                run(cmd=cmd, wait=False)
-                Log.info('Starting docker!')
-            else:
-                cmd = r'"C:\Program Files\Docker\Docker\Docker Desktop.exe"'
-                run(cmd=cmd, wait=False)
-                Log.info('Starting docker!')
+            if not Process.is_running_by_name('Docker Desktop'):
+                if docker is not None:
+                    cmd = '"' + os.path.join(docker, 'Docker Desktop.exe') + '"'
+                    run(cmd=cmd, wait=False)
+                    Log.info('Starting docker!')
+                else:
+                    cmd = r'"C:\Program Files\Docker\Docker\Docker Desktop.exe"'
+                    run(cmd=cmd, wait=False)
+                    Log.info('Starting docker!')
         elif OSUtils.is_catalina():
-            cmd = 'open --background -a Docker'
-            run(cmd=cmd, wait=False)
-            Log.info('Starting docker!')
+            if not Process.is_running_by_name('docker'):
+                cmd = 'open --background -a Docker'
+                run(cmd=cmd, wait=False)
+                Log.info('Starting docker!')
         else:
             Log.info('No need to start docker!')
 
     @staticmethod
     def stop():
-        if Settings.HOST_OS == OSType.WINDOWS:
-            Process.kill('Docker Desktop')
-            Process.kill('Docker.Watchguard')
-            Process.kill('com.docker.backend')
-            Process.kill('com.docker.proxy')
         if OSUtils.is_catalina():
             Process.kill('Docker')


### PR DESCRIPTION
On windows docker is very unstable. Lot of errors like: docker: Error response from daemon: error while creating mount source path : mkdir /host_mnt/c: file exists. 
To fix this we could try to keep docker running on windows and not restart it before every run because it seems to be more stable this way.
So on win: run docker only if it is not started and don't kill it after the run