### PR TITLE
fix: preview fallback path

### DIFF
--- a/core/settings/Settings.py
+++ b/core/settings/Settings.py
@@ -103,11 +103,19 @@ class Packages(object):
     if ENV == EnvironmentType.LIVE:
         __default_preview_folder = 'latest-official'
     PREVIEW_APP_ID = "org.nativescript.preview"
-    PREVIEW_PATH = os.environ.get('preview_folder_path', os.path.join("/tns-dist", "Playground",
-                                                                      "ns-play-dev", __default_preview_folder))
-    PLAYGROUND_PATH = os.environ.get('playground_folder_path', os.path.join("/tns-dist", "Playground",
-                                                                            "ns-play", __default_preview_folder))
-
+    if os.name == 'nt':
+        PREVIEW_PATH = os.environ.get('preview_folder_path',
+                                      os.path.join("\\telerik.com\distributions\DailyBuilds\NativeScript",
+                                                   "Playground","ns-play-dev", __default_preview_folder))
+        PLAYGROUND_PATH = os.environ.get('playground_folder_path',
+                                          os.path.join("\\telerik.com\distributions\DailyBuilds\NativeScript",
+                                                       "Playground", "ns-play", __default_preview_folder))
+    else:
+        PREVIEW_PATH = os.environ.get('preview_folder_path', os.path.join("/tns-dist", "Playground",
+                                                                          "ns-play-dev", __default_preview_folder))
+        PLAYGROUND_PATH = os.environ.get('playground_folder_path',os.path.join("/tns-dist", "Playground",
+                                                                               "ns-play", __default_preview_folder))
+    
     PREVIEW_APP_IOS = os.path.join(PREVIEW_PATH, "nsplaydev.tgz")
     PREVIEW_APP_ANDROID = os.path.join(PREVIEW_PATH, "app-universal-release.apk")
     PLAYGROUND_APP_IOS = os.path.join(PLAYGROUND_PATH, "nsplay.tgz")

--- a/core/settings/Settings.py
+++ b/core/settings/Settings.py
@@ -105,10 +105,10 @@ class Packages(object):
     PREVIEW_APP_ID = "org.nativescript.preview"
     if os.name == 'nt':
         PREVIEW_PATH = os.environ.get('preview_folder_path',
-                                      os.path.join("\\telerik.com\distributions\DailyBuilds\NativeScript",
+                                      os.path.join("\\\\telerik.com\\distributions\\DailyBuilds\\NativeScript",
                                                    "Playground","ns-play-dev", __default_preview_folder))
         PLAYGROUND_PATH = os.environ.get('playground_folder_path',
-                                          os.path.join("\\telerik.com\distributions\DailyBuilds\NativeScript",
+                                          os.path.join("\\\\telerik.com\\distributions\\DailyBuilds\\NativeScript",
                                                        "Playground", "ns-play", __default_preview_folder))
     else:
         PREVIEW_PATH = os.environ.get('preview_folder_path', os.path.join("/tns-dist", "Playground",

--- a/core/settings/Settings.py
+++ b/core/settings/Settings.py
@@ -106,16 +106,16 @@ class Packages(object):
     if os.name == 'nt':
         PREVIEW_PATH = os.environ.get('preview_folder_path',
                                       os.path.join("\\\\telerik.com\\distributions\\DailyBuilds\\NativeScript",
-                                                   "Playground","ns-play-dev", __default_preview_folder))
+                                                   "Playground", "ns-play-dev", __default_preview_folder))
         PLAYGROUND_PATH = os.environ.get('playground_folder_path',
-                                          os.path.join("\\\\telerik.com\\distributions\\DailyBuilds\\NativeScript",
-                                                       "Playground", "ns-play", __default_preview_folder))
+                                         os.path.join("\\\\telerik.com\\distributions\\DailyBuilds\\NativeScript",
+                                                      "Playground", "ns-play", __default_preview_folder))
     else:
         PREVIEW_PATH = os.environ.get('preview_folder_path', os.path.join("/tns-dist", "Playground",
                                                                           "ns-play-dev", __default_preview_folder))
-        PLAYGROUND_PATH = os.environ.get('playground_folder_path',os.path.join("/tns-dist", "Playground",
-                                                                               "ns-play", __default_preview_folder))
-    
+        PLAYGROUND_PATH = os.environ.get('playground_folder_path', os.path.join("/tns-dist", "Playground",
+                                                                                "ns-play", __default_preview_folder))
+
     PREVIEW_APP_IOS = os.path.join(PREVIEW_PATH, "nsplaydev.tgz")
     PREVIEW_APP_ANDROID = os.path.join(PREVIEW_PATH, "app-universal-release.apk")
     PLAYGROUND_APP_IOS = os.path.join(PLAYGROUND_PATH, "nsplay.tgz")


### PR DESCRIPTION
When preview_folder_path is not passed as env. variable  the fallback is only to /tns-dist but this is not working on windows. 
Fix: set preview falback path according to the os
This will fix failing pr in nativescript-dev-webpack wneh they try to run preview tests on win