### PR TITLE
fix: livesync failures

### DIFF
--- a/core/utils/docker.py
+++ b/core/utils/docker.py
@@ -23,7 +23,7 @@ class Docker(object):
                     run(cmd=cmd, wait=False)
                     Log.info('Starting docker!')
         elif OSUtils.is_catalina():
-            if not Process.is_running_by_name('docker'):
+            if not Process.is_running_by_name('Docker'):
                 cmd = 'open --background -a Docker'
                 run(cmd=cmd, wait=False)
                 Log.info('Starting docker!')

--- a/data/changes.py
+++ b/data/changes.py
@@ -66,7 +66,7 @@ class Changes(object):
                        old_value='Ter Stegen', new_value='Unknown',
                        old_text='Ter Stegen', new_text='Unknown')
         CSS = ChangeSet(file_path=os.path.join('src', 'app.css'),
-                        old_value='}', new_value='}\nListView { background-color: pink;}\n',
+                        old_value='}', new_value='}\nLabel{background-color:pink;}\n',
                         old_color=Colors.WHITE, new_color=Colors.PINK)
         HTML = ChangeSet(file_path=os.path.join('src', 'app', 'item', 'items.component.html'), old_value='"item.name"',
                          new_value='"item.id"', old_text=None, new_text=None)

--- a/data/changes.py
+++ b/data/changes.py
@@ -105,20 +105,20 @@ class Changes(object):
 
         # This change should make background of items on home page purple
         SCSS_NESTED_COMMON = ChangeSet(file_path=os.path.join('src', 'app', 'cars', '_car-list.component.scss'),
-                                       old_value='$background-color: background',
-                                       new_value='$background-color: purple',
-                                       old_color=Colors.WHITE, new_color=Colors.PURPLE_CUSTOM)
+                                       old_value='background-alt-10);',
+                                       new_value='background-alt-10);\nbackground-color: yellow;',
+                                       old_color=Colors.WHITE, new_color=Colors.YELLOW)
 
         # This change should make icons on home page yellow
         SCSS_NESTED_ANDROID = ChangeSet(file_path=os.path.join('src', 'app', 'cars', 'car-list.component.android.scss'),
                                         old_value='Android here',
-                                        new_value='Android here\n.cars-list__item{ color: yellow; }\n',
-                                        old_color=None, new_color=Colors.YELLOW)
+                                        new_value='Android here\n.cars-list__item-name{background-color: orange;}\n',
+                                        old_color=None, new_color=Colors.ORANGE)
 
         SCSS_NESTED_IOS = ChangeSet(file_path=os.path.join('src', 'app', 'cars', 'car-list.component.ios.scss'),
                                     old_value='iOS here',
-                                    new_value='iOS here\n.cars-list__item{ color: yellow; }\n',
-                                    old_color=None, new_color=Colors.YELLOW)
+                                    new_value='iOS here\n.cars-list__item-name{background-color: orange;}\n',
+                                    old_color=None, new_color=Colors.ORANGE)
 
     class JSTabNavigation(object):
         JS = ChangeSet(file_path=os.path.join('app', 'home', 'home-items-view-model.js'),

--- a/data/const.py
+++ b/data/const.py
@@ -19,4 +19,5 @@ class Colors(object):
     PURPLE_CUSTOM = numpy.array([255, 48, 129])  # A bit custom purple (when apply purple on master-detail).
     YELLOW = numpy.array([0, 255, 255])  # Yellow (standard CSS color).
     YELLOW_ICON = numpy.array([0, 242, 255])  # Yellow of star.png
+    ORANGE = numpy.array([0, 165, 255])  # Orange (standard CSS color).
     GREEN_ICON = numpy.array([0, 128, 0])  # Green of background colour of resources generate images

--- a/data/sync/hello_world_ng.py
+++ b/data/sync/hello_world_ng.py
@@ -8,7 +8,9 @@ from core.enums.app_type import AppType
 from core.enums.device_type import DeviceType
 from core.enums.platform_type import Platform
 from core.enums.os_type import OSType
+from core.log.log import Log
 from core.settings import Settings
+from core.utils.wait import Wait
 from data.changes import Changes, Sync
 from data.const import Colors
 from products.nativescript.preview_helpers import Preview
@@ -90,7 +92,9 @@ def sync_hello_world_ng(app_name, platform, device, bundle=True, uglify=False, a
                                    device=device)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180,
                          not_existing_string_list=not_existing_string_list)
-    device.wait_for_main_color(color=Changes.NGHelloWorld.CSS.new_color)
+    assert Wait.until(lambda: device.get_pixels_by_color(color=Changes.NGHelloWorld.CSS.new_color) > 100), \
+        'CSS on root level not applied!'
+    Log.info('CSS on root level applied successfully!')
 
     # Revert changes
     Sync.revert(app_name=app_name, change_set=Changes.NGHelloWorld.HTML)
@@ -116,7 +120,9 @@ def sync_hello_world_ng(app_name, platform, device, bundle=True, uglify=False, a
                                    device=device)
     TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=180,
                          not_existing_string_list=not_existing_string_list)
-    device.wait_for_main_color(color=Colors.WHITE)
+    assert Wait.until(lambda: device.get_pixels_by_color(color=Changes.NGHelloWorld.CSS.new_color) < 100), \
+        'CSS on root level not applied!'
+    Log.info('CSS on root level applied successfully!')
 
     # Assert final and initial states are same
     initial_state = os.path.join(Settings.TEST_OUT_IMAGES, device.name, 'initial_state.png')


### PR DESCRIPTION
After the new templates changes some tests that use the live sync workflows are failing in specific cases.
- Sync on iOS device fails with:Css not applied  Expected main color: [203 192 255]  Actual main color: [203 194 245] . On iOS devices version > 12.1 the pink appears with some nuance and is not exactly the same. 
Fix make other change that don't have differences between simulator and device and devices with different versions.
- master detail run on android on windows is failing with Platform specific nested SCSS not applied! The change is actually applied but because of the extensive color of the background and the small resolution of the emulator screen it is not recognized as exactly the same color.
Fix edit the changes so we don't change the whole background with some extensive color because this causes problems in some cases. 