### PR TITLE
fix: update expected stacktraces for CLI

### DIFF
--- a/tests/runtimes/ios/ios_runtime_tests.py
+++ b/tests/runtimes/ios/ios_runtime_tests.py
@@ -107,7 +107,7 @@ class IOSRuntimeTests(TnsTest):
                    'sig_handler(int)',
                    'JS Stack:',
                    '[native code]',
-                   'at onNavigatingTo(file:///app/main-page.js:34:0']
+                   'at onNavigatingTo(file: app/main-page.js:34:0']
         TnsLogs.wait_for_log(log_file=result.log_file, string_list=strings, timeout=150, check_interval=10)
 
         # Verify app is NOT running on device
@@ -149,7 +149,7 @@ class IOSRuntimeTests(TnsTest):
         log = Tns.run_ios(app_name=APP_NAME, emulator=True)
 
         strings = ['The folder “not-existing-path” doesn’t exist.',
-                   'JS:\ncontentsOfDirectoryAtPathError(file:///app/main-view-model.js:6:0)']
+                   'JS:\ncontentsOfDirectoryAtPathError(file: app/main-view-model.js:6:0)']
 
         test_result = Wait.until(lambda: all(string in File.read(log.log_file) for string in strings), timeout=300,
                                  period=5)


### PR DESCRIPTION
With latest changes in CLI the `file:///` part of the device logs is replaced by `file: `. Apply the change in the tests.

Changes are described in https://github.com/NativeScript/nativescript-cli/pull/5253