### PR TITLE
fix: set correct expected message for package-manager output

### DIFF
--- a/tests/cli/misc/pacakge_manager_tests.py
+++ b/tests/cli/misc/pacakge_manager_tests.py
@@ -17,4 +17,4 @@ class PackageManagerTests(TnsTest):
         result = Tns.exec_command(command='package-manager set fake')
         assert result.exit_code != 0, 'tns package-manager should exit with non zero exit code on fails.'
         assert 'fake is not a valid package manager.' in result.output, 'Wrong package manager not detected.'
-        assert 'Only yarn or npm are supported.' in result.output, 'No message for supported managers.'
+        assert 'Supported values are: npm, pnpm, yarn.' in result.output, 'No message for supported managers.'


### PR DESCRIPTION
CLI supports `pnpm` for package-manager and calling `tns package-manager set <invalid value>` should list all supported package managers. This is fixed in CLI, but the expected message in the tests should be fixed as well.

Related to: https://github.com/NativeScript/nativescript-cli/issues/5260 and https://github.com/NativeScript/nativescript-cli/pull/5265